### PR TITLE
xr.docs.pmnd.rs

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -11,7 +11,7 @@ jobs:
     with:
       mdx: './docs'
       libname: 'xr'
-      base_path: '/xr/docs'
+      base_path: '/docs'
       icon: '🤳'
       home_redirect: '/getting-started/introduction'
 


### PR DESCRIPTION
updated the base_path for docs

now you need to enable custom domain in Settings > Pages:

<img width="1879" alt="image" src="https://github.com/user-attachments/assets/58a1ba0c-13fc-47f7-8d90-05a7a6c01d97">

then re-trigger a build

![image](https://github.com/user-attachments/assets/b04592bd-447f-479b-a29d-2401eabc4851)
