### PR TITLE
Update XRInputSourceStateMap types

### DIFF
--- a/packages/xr/src/input.ts
+++ b/packages/xr/src/input.ts
@@ -73,6 +73,7 @@ export type XRInputSourceStateMap = {
   transientPointer: XRTransientPointerState
   gaze: XRGazeState
   screenInput: XRScreenInputState
+  gamepad: XRControllerGamepadState
 }
 
 function setupEvents(session: XRSession, events: Array<XRInputSourceEvent>): () => void {


### PR DESCRIPTION
The types are not including gamepad (however it shows up in console).