### PR TITLE
Name input source meshes

### DIFF
--- a/packages/xr/src/controller/model.ts
+++ b/packages/xr/src/controller/model.ts
@@ -22,6 +22,7 @@ export type XRControllerModelOptions = {
 }
 
 export function configureXRControllerModel(model: Object3D, options?: XRControllerModelOptions) {
+  model.name = 'XRControllerModel'
   model.renderOrder = options?.renderOrder ?? 0
   model.traverse((child) => {
     if (child instanceof Mesh && child.material instanceof Material) {

--- a/packages/xr/src/hand/model.ts
+++ b/packages/xr/src/hand/model.ts
@@ -47,6 +47,7 @@ export type XRHandModelOptions = {
 }
 
 export function configureXRHandModel(model: Object3D, options?: XRHandModelOptions) {
+  model.name = 'XRHandModel'
   model.renderOrder = options?.renderOrder ?? 0
   model.traverse((child) => {
     if (child instanceof Mesh && child.material instanceof Material) {

--- a/packages/xr/src/vanilla/pointer.ts
+++ b/packages/xr/src/vanilla/pointer.ts
@@ -10,6 +10,7 @@ export class PointerRayModel extends Mesh {
   constructor(pointer: Pointer, options: PointerRayModelOptions = {}) {
     const material = new PointerRayMaterial()
     super(pointerRayGeometry, material)
+    this.name = 'PointerRayModel'
     this.renderOrder = options.renderOrder ?? 2
     onXRFrame(() => updatePointerRayModel(this, material, pointer, options))
   }
@@ -21,6 +22,7 @@ export class PointerCursorModel extends Mesh {
   constructor(pointer: Pointer, options: PointerCursorModelOptions = {}) {
     const material = new PointerCursorMaterial()
     super(pointerCursorGeometry, material)
+    this.name = 'PointerCursorModel'
     this.renderOrder = options.renderOrder ?? 1
     onXRFrame(() => updatePointerCursorModel(this, material, pointer, options))
   }


### PR DESCRIPTION
We have a few render targets in the scene where we would like to hide input source models like hand, controller, pointer and ray. E.g. our xr screenshot component should ideally not include the input sources, for that we could traverse the scene and make things invisible by name.
@bbohlender, let me know if I missed another relevant visual geometry or if there is another preferred approach.