### PR TITLE
docs: Add GitHub icon to the top right of the document

### DIFF
--- a/.github/workflows/static.yml
+++ b/.github/workflows/static.yml
@@ -13,6 +13,7 @@ jobs:
       libname: 'xr'
       base_path: '/xr/docs'
       icon: '🤳'
+      github: 'https://github.com/pmndrs/xr'
       home_redirect: '/getting-started/introduction'
 
   examples:


### PR DESCRIPTION
Add a GitHub icon to the upper right corner of the document for quick access to the repository.

[AS-IS]
- The document lacks a direct link to the GitHub repository
- Users have to manually navigate to the GitHub page

[TO-BE]
- A GitHub icon is added to the top right corner of the document
- Clicking the icon will directly link users to the associated GitHub repository