### PR TITLE
Fixing minecraft example after hook changes

### DIFF
--- a/examples/minecraft/src/Player.tsx
+++ b/examples/minecraft/src/Player.tsx
@@ -36,7 +36,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
     backward,
     left,
     right,
-    rotationVelocity,
+    rotationYVelocity,
     velocity,
     newVelocity,
   }: {
@@ -44,7 +44,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
     backward: boolean
     left: boolean
     right: boolean
-    rotationVelocity: THREE.Euler
+    rotationYVelocity: number
     velocity?: Vector3Object
     newVelocity?: THREE.Vector3
   }) => {
@@ -58,7 +58,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
     //apply rotation
     const { x, y, z, w } = rigidBodyRef.current.rotation()
     quaternionHelper.set(x, y, z, w)
-    quaternionHelper.multiply(quaternionHelper2.setFromEuler(rotationVelocity))
+    quaternionHelper.multiply(quaternionHelper2.setFromEuler(new THREE.Euler(0, rotationYVelocity, 0)))
     rigidBodyRef.current?.setRotation(quaternionHelper, true)
 
     if (newVelocity) {
@@ -127,7 +127,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
         backward,
         left,
         right,
-        rotationVelocity: 0,
+        rotationYVelocity: 0,
         velocity,
       })
 

--- a/examples/minecraft/src/Player.tsx
+++ b/examples/minecraft/src/Player.tsx
@@ -24,7 +24,6 @@ const rotation = new THREE.Vector3()
 const vectorHelper = new THREE.Vector3()
 const quaternionHelper = new THREE.Quaternion()
 const quaternionHelper2 = new THREE.Quaternion()
-const eulerHelper = new THREE.Euler()
 
 export function Player({ lerp = THREE.MathUtils.lerp }) {
   const axe = useRef<THREE.Group>(null)
@@ -45,7 +44,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
     backward: boolean
     left: boolean
     right: boolean
-    rotationVelocity: number
+    rotationVelocity: THREE.Euler
     velocity?: Vector3Object
     newVelocity?: THREE.Vector3
   }) => {
@@ -59,7 +58,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
     //apply rotation
     const { x, y, z, w } = rigidBodyRef.current.rotation()
     quaternionHelper.set(x, y, z, w)
-    quaternionHelper.multiply(quaternionHelper2.setFromEuler(eulerHelper.set(0, rotationVelocity, 0, 'YXZ')))
+    quaternionHelper.multiply(quaternionHelper2.setFromEuler(rotationVelocity))
     rigidBodyRef.current?.setRotation(quaternionHelper, true)
 
     if (newVelocity) {

--- a/examples/minecraft/src/Player.tsx
+++ b/examples/minecraft/src/Player.tsx
@@ -24,6 +24,7 @@ const rotation = new THREE.Vector3()
 const vectorHelper = new THREE.Vector3()
 const quaternionHelper = new THREE.Quaternion()
 const quaternionHelper2 = new THREE.Quaternion()
+const eulerHelper = new THREE.Euler()
 
 export function Player({ lerp = THREE.MathUtils.lerp }) {
   const axe = useRef<THREE.Group>(null)
@@ -58,7 +59,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
     //apply rotation
     const { x, y, z, w } = rigidBodyRef.current.rotation()
     quaternionHelper.set(x, y, z, w)
-    quaternionHelper.multiply(quaternionHelper2.setFromEuler(new THREE.Euler(0, rotationYVelocity, 0)))
+    quaternionHelper.multiply(quaternionHelper2.setFromEuler(eulerHelper.set(0, rotationYVelocity, 0, 'YXZ')))
     rigidBodyRef.current?.setRotation(quaternionHelper, true)
 
     if (newVelocity) {

--- a/examples/minecraft/src/VRPlayerControl.tsx
+++ b/examples/minecraft/src/VRPlayerControl.tsx
@@ -13,20 +13,20 @@ export function VRPlayerControl({
     backward: boolean
     left: boolean
     right: boolean
-    rotationVelocity: number
+    rotationYVelocity: number
     velocity?: Vector3Object
     newVelocity?: THREE.Vector3
   }) => void
 }) {
   const controllerRight = useXRInputSourceState('controller', 'right')
 
-  const physicsMove = (velocity: THREE.Vector3, rotationVelocity: THREE.Euler) => {
+  const physicsMove = (velocity: THREE.Vector3, rotationYVelocity: number) => {
     playerMove({
       forward: false,
       backward: false,
       left: false,
       right: false,
-      rotationVelocity,
+      rotationYVelocity,
       velocity: undefined,
       newVelocity: velocity,
     })

--- a/examples/minecraft/src/VRPlayerControl.tsx
+++ b/examples/minecraft/src/VRPlayerControl.tsx
@@ -20,7 +20,7 @@ export function VRPlayerControl({
 }) {
   const controllerRight = useXRInputSourceState('controller', 'right')
 
-  const physicsMove = (velocity: THREE.Vector3, rotationVelocity: number) => {
+  const physicsMove = (velocity: THREE.Vector3, rotationVelocity: THREE.Euler) => {
     playerMove({
       forward: false,
       backward: false,


### PR DESCRIPTION
This example wasn't quite patched after the last round of changes, so I've now modified it to reflect the latest iteration of the `useControllerLocomotion` hook