### PR TITLE
docs: Update outdated info in the gamepad.md tutorial, and added a better description for the useXRInputSourceEvent hook and js doc

### DIFF
--- a/docs/getting-started/all-hooks.md
+++ b/docs/getting-started/all-hooks.md
@@ -54,7 +54,14 @@ Inputs are a key aspect of react-three/fiber. The following hooks provide access
 
 ### `useXRInputSourceEvent`
 
-Hook for listening to xr input source events.
+Hook for listening to xr input source events. [List of events](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSourceEvent).
+
+ - `inputSource`: The input source to listen to, or 'all' to listen to all input sources
+ - `event`: The event to listen to. ([List of events](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSourceEvent))
+ - `fn`: Callback function called when the event is triggered.
+ - `deps`: Retriggers the binding of the event when the dependencies change.
+
+ex: `useXRInputSourceEvent('all', "selectstart", (event) => console.log(event))`
 
 ### `useXRInputSourceStateContext`
 

--- a/docs/tutorials/gamepad.md
+++ b/docs/tutorials/gamepad.md
@@ -4,11 +4,11 @@ description: How to use the XRControllers gamepad?
 nav: 13
 ---
 
-All XR controllers are part of the state inside the xr store. The existing controllers can be read using the `useXR` hook. Alternatively, a specific xr controller can be retrived using `useXRController("left")`.
+All XR controllers are part of the state inside the xr store. The existing controllers can be read using the `useXR` hook. Alternatively, a specific xr controller can be retrived using `useXRInputSourceState("controller", "left")`.
 
 The xr controller state contains the gamepad state. Based on the name of one specific component, its state can be polled every frame. The following example shows how to read the thumbstick of the right controller to implement locomotion in combination with the `XROrigin`.
 
-To keep the code snipped focussed on the gamepad API, the locomotion does not happen relative to the users head rotation. This can be added by retrieving the users head position from reading the camera world quaternion and extracting the users rotation on the y axis.
+To keep the code snipped focussed on the gamepad API, the locomotion does not happen relative to the users head rotation. This can be added by retrieving the users head position from reading the camera world quaternion and extracting the users rotation on the y axis. (There is also a [useXRControllerLocomotion](../getting-started/all-hooks.md#usexrcontrollerlocomotion) hook available to help avoid implementing locomotion from scratch if that is the end goal).
 
 ```tsx
 const store = createXRStore()

--- a/packages/react/xr/src/input.tsx
+++ b/packages/react/xr/src/input.tsx
@@ -48,7 +48,11 @@ export function useXRInputSourceStateContext<T extends keyof XRInputSourceStateM
 }
 
 /**
- * hook for listening to xr input source events
+ * Hook for listening to xr input source events
+ * @param inputSource The input source to listen to, or 'all' to listen to all input sources
+ * @param event The event to listen to. ([List of events](https://developer.mozilla.org/en-US/docs/Web/API/XRInputSourceEvent))
+ * @param fn Callback function called when the event is triggered.
+ * @param deps Retriggers the binding of the event when the dependencies change.
  */
 export function useXRInputSourceEvent(
   inputSource: XRInputSource | 'all' | undefined,


### PR DESCRIPTION
# Changes
- Updated some outdated information on the gamepad.md tutorial
- Added some JSdoc and a better description for the `useXRInputSourceEvent` hook