### PR TITLE
Add normal attribute to object returned by RayIntersector

### DIFF
--- a/packages/pointer-events/src/intersections/ray.ts
+++ b/packages/pointer-events/src/intersections/ray.ts
@@ -135,6 +135,7 @@ export class RayIntersector implements Intersector {
       pointerPosition,
       pointerQuaternion,
       pointOnFace: intersection.point,
+      normal: intersection.face?.normal,
       localPoint: intersection.point
         .clone()
         .applyMatrix4(invertedMatrixHelper.copy(intersection.object.matrixWorld).invert()),


### PR DESCRIPTION
This attribute is used in the xr package but is currently undefined. This one-line change fixes cursor behaviour.