### PR TITLE
Access intersection.face.normal instead of intersection.normal

### DIFF
--- a/packages/xr/src/pointer/cursor.ts
+++ b/packages/xr/src/pointer/cursor.ts
@@ -93,8 +93,8 @@ export function updatePointerCursorModel(
 
   mesh.position.copy(intersection.pointOnFace)
   mesh.scale.setScalar(options.size ?? 0.1)
-  if (intersection.normal != null) {
-    quaternionHelper.setFromUnitVectors(ZAxis, intersection.normal)
+  if (intersection.face.normal != null) {
+    quaternionHelper.setFromUnitVectors(ZAxis, intersection.face.normal)
     intersection.object.getWorldQuaternion(mesh.quaternion)
     mesh.quaternion.multiply(quaternionHelper)
     offsetHelper.set(0, 0, options.cursorOffset ?? 0.01)


### PR DESCRIPTION
intersection.normal was always undefined and that caused the cursor to always keep the same orientation 
Same as #387 but respects threejs's behavior (I think)