### PR TITLE
make fallback layer transparent when blendTextureSourceAlpha is true

### DIFF
--- a/packages/react/xr/src/layer.tsx
+++ b/packages/react/xr/src/layer.tsx
@@ -315,7 +315,7 @@ export const FallbackXRLayerImplementation = forwardRef<
   }, [src, pixelWidth, pixelHeight, dpr, renderTargetRef])
   return (
     <mesh ref={ref} {...props}>
-      <meshBasicMaterial ref={materialRef} toneMapped={false} />
+      <meshBasicMaterial ref={materialRef} toneMapped={false} transparent={!!props.blendTextureSourceAlpha} />
     </mesh>
   )
 })


### PR DESCRIPTION
This ensures the fallback layer follows the same behavior as the native layer. 
I have only tested this by modifying `node_modules/@react-three/xr/dist/layer.js` in my project's folder, but it seems to be working as intended. 
I'd probably need to add the modification to vanilla too. Tell me if you want to merge this and I'll add that to the PR