### PR TITLE
useIsInSessionMode returns true by default only during active XR session

### DIFF
--- a/packages/react/xr/src/guard/session-mode.tsx
+++ b/packages/react/xr/src/guard/session-mode.tsx
@@ -12,7 +12,7 @@ function useIsInSessionMode(
   if (allow != null) {
     return Array.isArray(allow) ? allow.includes(mode) : allow === mode
   }
-  return true
+  return mode !== null
 }
 
 /**


### PR DESCRIPTION
I found it quite unintuitive that useIsInSessionMode will always return true if neither allow nor deny is provided. With this simple change, one can quickly wrap components with `<IfInSessionMode>` without providing arguments to include the children only if any xr session is actually active.