### PR TITLE
Change some parameters in HandleStore to protected to unblock child class implementation

### DIFF
--- a/packages/handle/src/store.ts
+++ b/packages/handle/src/store.ts
@@ -91,8 +91,8 @@ export class HandleStore<T>
   implements OnePointerHandleStoreData, TwoPointerHandleStoreData, TranslateAsHandleStoreData
 {
   //internal out state (will be used to output the state)
-  private outputState: HandleStateImpl<T>
-  private latestMoveEvent: PointerEvent | undefined
+  protected outputState: HandleStateImpl<T>
+  protected latestMoveEvent: PointerEvent | undefined
 
   //internal in state (will be written on save)
   readonly inputState = new Map<
@@ -253,7 +253,7 @@ export class HandleStore<T>
     this.latestMoveEvent = undefined
   }
 
-  private getTarget() {
+  protected getTarget() {
     return this.target instanceof Object3D ? this.target : this.target?.current
   }
 
@@ -292,7 +292,7 @@ export class HandleStore<T>
     event.stopPropagation()
   }
 
-  private apply(target: Object3D): T {
+  protected apply(target: Object3D): T {
     const apply = this.getOptions().apply ?? defaultApply
     return apply(this.outputState, target)
   }


### PR DESCRIPTION
When I was implementing a child class of HandleStore I found it challenging as some of the key parameters and methods are not accessible from inherited classes. I think we could update them as protected to allow child class accessibility while keeping it non-accessible by the usage classes. 