### PR TITLE
Add disabled prop to XROrigin component

### DIFF
--- a/packages/react/xr/src/origin.tsx
+++ b/packages/react/xr/src/origin.tsx
@@ -4,6 +4,10 @@ import { Group } from 'three'
 import { xrSpaceContext } from './contexts.js'
 import { useXR } from './xr.js'
 
+export type XROriginProps = ThreeElements['group'] & {
+  disabled?: boolean
+}
+
 /**
  * Component for setting the origin of the player (their feet)
  *
@@ -11,22 +15,27 @@ import { useXR } from './xr.js'
  * Accepts the same props as a ThreeJs [Group](https://threejs.org/docs/#api/en/objects/Group)
  * @function
  */
-export const XROrigin = forwardRef<Group, ThreeElements['group']>(({ children, ...props }, ref) => {
+export const XROrigin = forwardRef<Group, XROriginProps>(({ children, disabled, ...props }, ref) => {
   const xrCamera = useThree((s) => s.gl.xr.getCamera())
   const internalRef = useRef<Group>(null)
-  useImperativeHandle(ref, () => internalRef.current!, [])
   const referenceSpace = useXR((xr) => xr.originReferenceSpace)
+
+  useImperativeHandle(ref, () => internalRef.current!, [])
+
   useEffect(() => {
     const group = internalRef.current
-    if (group == null) {
+    if (!group || disabled) {
       return
     }
+
     group.add(xrCamera)
+
     return () => void group.remove(xrCamera)
-  }, [xrCamera])
+  }, [disabled, xrCamera])
+
   return (
     <group ref={internalRef} {...props}>
-      {referenceSpace != null && <xrSpaceContext.Provider value={referenceSpace}>{children}</xrSpaceContext.Provider>}
+      {referenceSpace && <xrSpaceContext.Provider value={referenceSpace}>{children}</xrSpaceContext.Provider>}
     </group>
   )
 })

--- a/packages/react/xr/src/origin.tsx
+++ b/packages/react/xr/src/origin.tsx
@@ -24,7 +24,7 @@ export const XROrigin = forwardRef<Group, XROriginProps>(({ children, disabled, 
 
   useEffect(() => {
     const group = internalRef.current
-    if (!group || disabled) {
+    if (group == null || disabled) {
       return
     }
 

--- a/packages/react/xr/src/origin.tsx
+++ b/packages/react/xr/src/origin.tsx
@@ -35,7 +35,7 @@ export const XROrigin = forwardRef<Group, XROriginProps>(({ children, disabled, 
 
   return (
     <group ref={internalRef} {...props}>
-      {referenceSpace && <xrSpaceContext.Provider value={referenceSpace}>{children}</xrSpaceContext.Provider>}
+      <xrSpaceContext.Provider value={referenceSpace}>{children}</xrSpaceContext.Provider>
     </group>
   )
 })


### PR DESCRIPTION
In anticipation of play state support for Triplex WebXR I need to be able to disable userland XROrigin components when in "edit" state, but continue rendering them in the scene so their helper can be displayed in the scene.

This pull request adds `disabled` prop to the XROrigin component keeping it in line with what we did for the transform handles. Let me know if you think we should not render children when disabled (I'll annotate what I'm talking about).