### PR TITLE
Add safe access XR store hook

### DIFF
--- a/packages/react/xr/src/xr.tsx
+++ b/packages/react/xr/src/xr.tsx
@@ -145,9 +145,10 @@ export function useXRStore() {
 }
 
 /**
- * Hook for getting the xr store from context. If not available `undefined` is returned.
+ * Returns the XR store object from a parent {@link XR} component. If no component is found `undefined` is returned.
+ * You most likely should be using {@link useXRStore} instead.
  */
-export function useXRStoreSafe() {
+export function UNSAFE_useXRStore() {
   const store = useContext(xrContext)
   return store
 }

--- a/packages/react/xr/src/xr.tsx
+++ b/packages/react/xr/src/xr.tsx
@@ -145,6 +145,14 @@ export function useXRStore() {
 }
 
 /**
+ * Hook for getting the xr store from context. If not available `undefined` is returned.
+ */
+export function useXRStoreSafe() {
+  const store = useContext(xrContext)
+  return store
+}
+
+/**
  * Hook for reading the state from the xr store
  */
 export function useXR<T = XRState>(


### PR DESCRIPTION
In Triplex to support play states I need to be able to pick off userland XR context if it exists and then apply it to the bottom most XR provider in Triplex (so: Triplex always "owns" the bottom most XR state).

Userland XR state may not exist. If that's the case I still need the session to function, so this exposes a new XR store hook that won't throw an invariant if it's missing.

I've named it to discourage usage, but let me know if this tracks with your thoughts.