### PR TITLE
feat: Adding a webXR primer tutorial

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
 
   // Run the equivalent of `eslint --fix` each time you save
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 
   // Disable the built‑in “Organize Imports” so it doesn’t fight ESLint

--- a/docs/advanced/performance.md
+++ b/docs/advanced/performance.md
@@ -1,7 +1,7 @@
 ---
 title: Performance
 description: Important considerations for building performant immersive web applications with react-three/xr
-nav: 22
+nav: 23
 ---
 
 All performance optimizations for non-immersive 3D web applications are also applicable for immersive XR web applications. Relevant guides on the topic of performance for 3D web applications are the [R3F performance guide](https://docs.pmnd.rs/react-three-fiber/advanced/scaling-performance), [R3F performance pitfalls](https://docs.pmnd.rs/react-three-fiber/advanced/pitfalls), and the [Threejs tips and tricks](https://discoverthreejs.com/tips-and-tricks/#performance). In general, it is good to check if your web application's performance is GPU- or CPU-bound to select the correct optimization techniques.

--- a/docs/handles/handle-component.md
+++ b/docs/handles/handle-component.md
@@ -1,7 +1,7 @@
 ---
 title: Handle Component  
 description: The Handle and HandleTarget components and their properties  
-nav: 24  
+nav: 25  
 ---
 
 The `Handle` component is the core component of the `@react-three/handle` library, which is built on the `HandleStore`. This store provides developers with more control over the current state and user interactions.

--- a/docs/handles/introduction.md
+++ b/docs/handles/introduction.md
@@ -1,7 +1,7 @@
 ---
 title: Handles  
 description: Easily build 3D interactions using the concept of handles  
-nav: 23  
+nav: 24  
 ---
 
 Handles are everywhere, from scrollbar thumbs to window bars to door handles.

--- a/docs/handles/prebuild-handles.md
+++ b/docs/handles/prebuild-handles.md
@@ -1,7 +1,7 @@
 ---
 title: Prebuilt Handles for Editor Use Cases  
 description: The Handle and HandleTarget components and their properties  
-nav: 25  
+nav: 26  
 ---
 
 The `Handle` component allows for the orchestration of multiple handles together to achieve interactions typically found in 3D editors, such as the `TransformControls` offered by Three.js. Since these prebuilt handles are commonly used, `@react-three/handles` includes two of them: `TransformHandles` (based on TransformControls from Three.js) and `PivotHandles` (based on PivotControls from @react-three/drei). These prebuilt handles can be used in XR and non-XR environments, are highly configurable for use cases including multi-user editing, can be utilized through virtual screens, and respect the event system of the scene, preventing accidental interactions with multiple objects at once.

--- a/docs/handles/screen-handle-components.md
+++ b/docs/handles/screen-handle-components.md
@@ -1,7 +1,7 @@
 ---
 title: Screen Handles  
 description: Orbit and Map Handles as replacements for Orbit and Map controls  
-nav: 26  
+nav: 27  
 ---
 
 Screen handles are available for screen-based devices like smartphones and PCs and allow users to move the camera by dragging, swiping, and scrolling on the screen. Three.js directly offers `OrbitControls` and `MapControls`, which are built for this purpose, and we are building on top of their success. The main difference is that the `OrbitHandles` and `MapHandles` we provide use the event system of the scene, which means that interactions with objects in the scene prevent dragging the camera. Furthermore, the event system can forward the screen inputs on a virtual screen to a virtual camera inside a virtual scene, which is showcased in the [editor example](https://pmndrs.github.io/xr/examples/editor/).

--- a/docs/migration/from-natuerlich.md
+++ b/docs/migration/from-natuerlich.md
@@ -1,7 +1,7 @@
 ---
 title: from Natuerlich
 description: Migrate your application from natuerlich
-nav: 24
+nav: 25
 ---
 
 @react-three/xr is inspired by natuerlich, and therefore, many things are similar, especially the way interactions are handled. However, a few things have been changed and renamed.

--- a/docs/migration/from-react-three-xr-5.md
+++ b/docs/migration/from-react-three-xr-5.md
@@ -1,7 +1,7 @@
 ---
 title: from @react-three/xr v5
 description: Migrate your application from @react-three/xr v5
-nav: 23
+nav: 24
 ---
 
 The goal of @react-three/xr v6 is to align this library closer to the react-three ecosystem. We, therefore, focussed on supporting the react-three/fiber event handlers. Another focus of v6 is to reduce boilerplate and provide more defaults while also giving developers more access to the lower-level WebXR primitives. In combination, these changes allow developers to build XR experiences that interoperate with the whole react-three ecosystem using only a few lines of code. 

--- a/docs/tutorials/anchors.md
+++ b/docs/tutorials/anchors.md
@@ -1,7 +1,7 @@
 ---
 title: Anchors
 description: How to create and manage anchors in your AR experience?
-nav: 17
+nav: 18
 ---
 
 Anchors allow to anchor virtual objects into the physical world in AR experiences. `react-three/xr` offers a multitude of ways to create and manage anchors. A simple solution is `useXRAnchor`, which works similarly to `useState` as it returns the current anchor and a function to request a new anchor as a tuple.

--- a/docs/tutorials/custom-inputs.md
+++ b/docs/tutorials/custom-inputs.md
@@ -1,7 +1,7 @@
 ---
 title: Custom Hands/Controllers/...
 description: Customize interactions and style of inputs such as hands, controllers, and more
-nav: 16
+nav: 17
 ---
 
 @react-three/xr provides a set of default hands, controllers, transient pointers, gazes, and screen input that can be configured and completely exchanged with your own implementation. The following example shows how to configure the ray color of the ray pointer in the users hand.

--- a/docs/tutorials/dom-overlay.md
+++ b/docs/tutorials/dom-overlay.md
@@ -1,7 +1,7 @@
 ---
 title: Dom Overlay
 description: How to add HTML elements for hand-held AR experiences with Dom overlay?
-nav: 18
+nav: 19
 ---
 
 For hand-held AR experiences, such as those using a Smartphone, WebXR offers the dom overlay capability, allowing developers to use HTML code overlayed over the experience. In case scene 3D overlays or overlays in non-handheld AR/VR experiences are needed, check out [pmndrs/uikit](https://github.com/pmndrs/uikit).

--- a/docs/tutorials/gamepad.md
+++ b/docs/tutorials/gamepad.md
@@ -1,7 +1,7 @@
 ---
 title: Gamepad
 description: How to use the XRControllers gamepad?
-nav: 13
+nav: 14
 ---
 
 All XR controllers are part of the state inside the xr store. The existing controllers can be read using the `useXR` hook. Alternatively, a specific xr controller can be retrived using `useXRInputSourceState("controller", "left")`.

--- a/docs/tutorials/guards.md
+++ b/docs/tutorials/guards.md
@@ -1,7 +1,7 @@
 ---
 title: Guards
 description: Render and show parts of your application conditionally using guards
-nav: 20
+nav: 21
 ---
 
 Guards allow to conditionally display or include content. For instance, the `IfInSessionMode` guard allows only displaying a background when the session is not an AR session. The `IfInSessionMode` can receive either a list of `allow` session modes or a list of `deny` session modes.

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -1,7 +1,7 @@
 ---
 title: Hit Test
 description: How to add hit testing capabilities to your AR experiences?
-nav: 19
+nav: 20
 ---
 
 Hit testing allows to check intersections with real-world geometry in AR experiences. `@react-three/xr` provides various hooks and components for setting up hit testing.

--- a/docs/tutorials/layers.md
+++ b/docs/tutorials/layers.md
@@ -1,7 +1,7 @@
 ---
 title: Layers
 description: How to use display images, videos, and custom renders at high quality on quad, cylinder, and equirect shapes?
-nav: 15
+nav: 16
 ---
 
 Layers allow to render videos, images, and complete scenes with higher performance and higher quality while preserving battery life and latency for quad, cylinder, and equirect shapes using the WebXR Layer API. Layers are perfect for use cases that display flat, high-quality content, such as videos, images, and user interfaces. The following example illustrates how to create a layer that renders a video.

--- a/docs/tutorials/secondary-input-sources.md
+++ b/docs/tutorials/secondary-input-sources.md
@@ -1,7 +1,7 @@
 ---
 title: Secondary Input Sources
 description: How to use primary and secondary input sources (multiple controllers and hands) simultaneously?
-nav: 14
+nav: 15
 ---
 
 Most standalone XR headsets support hand and controller tracking. While typical XR experiences often support both input methods, they only use the primary inputs, which refers to one input per hand and limits the inputs to `2`. However, the headset often also tracks the secondary input sources. By enabling the `secondaryInputSources` flag when creating an xr store, we can access the secondary input sources and use them to track real-world objects, for example.

--- a/docs/tutorials/webxr-spaces-primer.md
+++ b/docs/tutorials/webxr-spaces-primer.md
@@ -1,0 +1,8 @@
+---
+title: WebXR Spaces
+description: A short experience to help understand how spaces work in WebXR
+nav: 13
+---
+
+Spaces are core to any WebXR experience, and understanding which spaces are available, when to use them, and how they interact with each other can be a huge benefit when building XR experiences. The codesandbox below is a simple experience to show how various spaces work together in a WebXR environment. 
+

--- a/docs/tutorials/webxr-spaces-primer.md
+++ b/docs/tutorials/webxr-spaces-primer.md
@@ -1,8 +1,0 @@
----
-title: WebXR Spaces
-description: A short experience to help understand how spaces work in WebXR
-nav: 13
----
-
-Spaces are core to any WebXR experience, and understanding which spaces are available, when to use them, and how they interact with each other can be a huge benefit when building XR experiences. The codesandbox below is a simple experience to show how various spaces work together in a WebXR environment. 
-

--- a/docs/tutorials/webxr-spaces-primer.mdx
+++ b/docs/tutorials/webxr-spaces-primer.mdx
@@ -1,0 +1,15 @@
+---
+title: WebXR Spaces
+description: A short experience to help understand how spaces work in WebXR
+nav: 13
+---
+
+Spaces are core to any WebXR experience, and understanding which spaces are available, when to use them, and how they interact with each other can be a huge benefit when building XR experiences. The codesandbox below is a simple experience to show how various spaces work together in a WebXR environment. 
+
+
+<iframe src="https://codesandbox.io/embed/jff76z?view=editor+%2B+preview&module=%2Fsrc%2FApp.tsx"
+     style={{width:"100%", height: "500px", border:0, borderRadius: "4px", overflow:"hidden"}}
+     title="WebXRSpacesStarter"
+     allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+     sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+   />

--- a/packages/react/xr/plugins/pretty-md.mjs
+++ b/packages/react/xr/plugins/pretty-md.mjs
@@ -140,7 +140,7 @@ export const load = (app) => {
 
           // Update the nav number in the frontmatter
           const content = fs.readFileSync(targetFile, 'utf-8')
-          const updatedContent = content.replace(/nav:\s*\d+/, `nav: ${index + 25}`)
+          const updatedContent = content.replace(/nav:\s*\d+/, `nav: ${index + 26}`)
           fs.writeFileSync(targetFile, updatedContent)
         })
       }


### PR DESCRIPTION
# Changes
- Added a new tutorial page and embedded a link to the CodeSandbox with the WebXR primer project
- Updated eslint rule to match the correct current syntax
- Bumped all of the navigation numbers so that the paging continues to work correctly



![image](https://github.com/user-attachments/assets/162b945d-869d-49dd-88bc-aaf38912c955)
