### PR TITLE
PivotControls: add unform scaling handle

### DIFF
--- a/packages/handle/src/handles/material.ts
+++ b/packages/handle/src/handles/material.ts
@@ -38,7 +38,7 @@ export function setupHandlesContextHoverMaterial(
   }
   hoverColor ??= color
   return context.subscribeHover((tags) => {
-    const isHovered = tags.some((activeTag) => activeTag.includes(tag))
+    const isHovered = tags.some((activeTag) => activeTag === tag)
     material.color.set(isHovered ? hoverColor : color)
     material.opacity = (isHovered ? hoverOpacity : opacity) ?? 1
   })

--- a/packages/handle/src/handles/pivot/index.ts
+++ b/packages/handle/src/handles/pivot/index.ts
@@ -14,6 +14,7 @@ export class PivotHandlesHandles extends Group {
   public readonly scaleX: PivotAxisScaleHandle
   public readonly scaleY: PivotAxisScaleHandle
   public readonly scaleZ: PivotAxisScaleHandle
+  public readonly scaleXYZ: PivotAxisScaleHandle
 
   public readonly rotationX: PivotAxisRotationHandle
   public readonly rotationY: PivotAxisRotationHandle
@@ -49,6 +50,8 @@ export class PivotHandlesHandles extends Group {
     this.scaleZ = new PivotAxisScaleHandle(context, 'z', 's')
     this.scaleZ.rotation.y = -Math.PI / 2
     this.add(this.scaleZ)
+    this.scaleXYZ = new PivotAxisScaleHandle(context, 'xyz', 's')
+    this.add(this.scaleXYZ)
     this.rotationX = new PivotAxisRotationHandle(context, 'x', 'r', this.xRotationAxis)
     this.add(this.rotationX)
     this.rotationY = new PivotAxisRotationHandle(context, 'y', 'r', this.yRotationAxis)
@@ -100,6 +103,7 @@ export class PivotHandlesHandles extends Group {
     const unbindScaleX = this.scaleX.bind(0xff2060, scale)
     const unbindScaleY = this.scaleY.bind(0x20df80, scale)
     const unbindScaleZ = this.scaleZ.bind(0x2080ff, scale)
+    const unbindScaleXYZ = this.scaleXYZ.bind(0xa0a0a0, scale)
     const unbindRotationX = this.rotationX.bind(0xff2060, rotation)
     const unbindRotationY = this.rotationY.bind(0x20df80, rotation)
     const unbindRotationZ = this.rotationZ.bind(0x2080ff, rotation)
@@ -113,6 +117,7 @@ export class PivotHandlesHandles extends Group {
       unbindScaleX?.()
       unbindScaleY?.()
       unbindScaleZ?.()
+      unbindScaleXYZ?.()
       unbindRotationX?.()
       unbindRotationY?.()
       unbindRotationZ?.()

--- a/packages/handle/src/handles/pivot/scale.ts
+++ b/packages/handle/src/handles/pivot/scale.ts
@@ -7,9 +7,9 @@ import { RegisteredHandle } from '../registered.js'
 import { extractHandleTransformOptions } from '../utils.js'
 
 export class PivotAxisScaleHandle extends RegisteredHandle {
-  constructor(context: HandlesContext, axis: Axis, tagPrefix: string) {
+  constructor(context: HandlesContext, axis: Axis | 'xyz', tagPrefix: string) {
     super(context, axis, tagPrefix, () => ({
-      scale: this.options,
+      scale: axis === 'xyz' ? { uniform: true, ...this.options } : this.options,
       rotate: false,
       translate: 'as-scale',
       multitouch: false,
@@ -29,10 +29,16 @@ export class PivotAxisScaleHandle extends RegisteredHandle {
       disabled,
     })
 
-    const mesh = new Mesh(new SphereGeometry(0.04), material)
+    let handleSize = 0.04
+    let handleOffset = 0.68
+    if (this.axis === 'xyz') {
+      handleSize = 0.08
+      handleOffset = 0
+    }
+    const mesh = new Mesh(new SphereGeometry(handleSize), material)
     mesh.renderOrder = Infinity
     mesh.pointerEventsOrder = Infinity
-    mesh.position.x = 0.68
+    mesh.position.x = handleOffset
 
     const unregister = disabled ? undefined : this.context.registerHandle(this.store, mesh, this.tag)
 

--- a/packages/react/handle/src/handles/pivot.tsx
+++ b/packages/react/handle/src/handles/pivot.tsx
@@ -94,6 +94,10 @@ export const PivotHandlesHandles = forwardRef<PivotHandlesHandlesImpl, PivotHand
       [disabled, scale, handles, hidden],
     )
     useEffect(
+      () => (hidden ? undefined : handles.scaleXYZ.bind(0xa0a0a0, disabled ? disableProperties(scale) : scale)),
+      [disabled, scale, handles, hidden],
+    )
+    useEffect(
       () => (hidden ? undefined : handles.rotationX.bind(0xff2060, disabled ? disableProperties(rotation) : rotation)),
       [disabled, rotation, handles, hidden],
     )


### PR DESCRIPTION
This PR adds a uniform scaling handle at the center of PivotControls, first discussed in #414. I have added the handle at the center as that seems to be a common location for uniform scaling handle, similar to both Unity and Blender. I have made the Sphere mesh size a bit larger than the individual axis handles as otherwise there is very little space for scaling down. I have also changed the highlighting tag comparison to be exact string match instead of 'includes' to separate 'sx' and 'sxyz' tags. Open to feedback and changes!
![image](https://github.com/user-attachments/assets/f3dbb6c1-955f-4f9a-8aa5-1e1ab5c6f9aa)
