### PR TITLE
docs: Update hit testing tutorial and example

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,7 +4,7 @@
 
   // Run the equivalent of `eslint --fix` each time you save
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   },
 
   // Disable the built‑in “Organize Imports” so it doesn’t fight ESLint

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -22,9 +22,13 @@ All rays cast by these components originate from the source's position and are c
 
 The `useXRHitTest` hook is the most commonly used hook for hit testing in the library. It automatically performs hit tests every frame and calls your callback function with the results.
 
-**What it does:** Sets up continuous hit testing that runs every frame, providing real-time intersection data with the real world.
+**What it does:**
 
-**When to use it:** Use this when you need continuous tracking of where a ray intersects with real-world surfaces, such as for cursor positioning, object placement previews, or interactive AR elements.
+Sets up continuous hit testing that runs every frame, providing real-time intersection data with the real world.
+
+**When to use it:**
+
+Use this when you need continuous tracking of where a ray intersects with real-world surfaces, such as for cursor positioning, object placement previews, or interactive AR elements.
 
 **Parameters:**
 
@@ -101,16 +105,22 @@ const store = createXRStore({
 
 The `useXRHitTestSource` hook provides lower-level access to hit test sources, giving you more control over when and how hit tests are performed. It is the same as the `useXRHitTest` hook, the only difference being that you have to manually check for hit test results; typically every frame, or every few frames.
 
-**What it does:** Does the same thing as the `useXRHitTest` hook, but does not automatically hit test every frame.
+**What it does:** 
 
-**When to use it:** In most cases you should use either `useXRHitTest` or `useXRRequestHitTest`, but you can use this hook when you have a static hit test source that you only want to occasionally perform constant hit tests from. Or if you want to recreate the `useXRHitTest` behavior manually.
+Does the same thing as the `useXRHitTest` hook, but does not automatically hit test every frame.
+
+**When to use it:**
+
+ In most cases you should use either `useXRHitTest` or `useXRRequestHitTest`, but you can use this hook when you have a static hit test source that you only want to occasionally perform constant hit tests from. Or if you want to recreate the `useXRHitTest` behavior manually.
 
 **Parameters:**
 
 - `relativeTo` - The object, XR space, or reference space to cast rays from
 - `trackableType` - Optional parameter specifying what types of surfaces to hit test against
 
-**Returns:** A hit test source object that you can use with `frame.getHitTestResults()`
+**Returns:**
+
+ A hit test source object that you can use with `frame.getHitTestResults()`
 
 ```tsx
 function ManualHitTest() {
@@ -150,11 +160,17 @@ function ManualHitTest() {
 
 The `useXRRequestHitTest` hook provides a function for one-time hit test requests. Useful for event-driven hit testing. Cannot be called in the `useFrame` hook.
 
-**What it does:** Returns a function that can perform a single hit test request when called.
+**What it does:** 
 
-**When to use it:** Use this for event-driven hit testing, such as when a user taps the screen, clicks a button, or performs a gesture. It's ideal for placing objects or checking intersections at specific moments.
+Returns a function that can perform a single hit test request when called.
 
-**Returns:** A function that takes the same parameters as other hit test hooks and returns a promise with hit test results
+**When to use it:** 
+
+Use this for event-driven hit testing, such as when a user taps the screen, clicks a button, or performs a gesture. It's ideal for placing objects or checking intersections at specific moments.
+
+**Returns:** 
+
+A function that takes the same parameters as other hit test hooks and returns a promise with hit test results
 
 ```tsx
 const matrixHelper = new Matrix4()

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -27,10 +27,10 @@ The `useXRHitTest` hook is the most commonly used hook for hit testing in the li
 **When to use it:** Use this when you need continuous tracking of where a ray intersects with real-world surfaces, such as for cursor positioning, object placement previews, or interactive AR elements.
 
 **Parameters:**
-- `fn` - Callback function that receives hit test results and a function to retrieve the world matrix 
+
+- `fn` - Callback function that receives hit test results and a function to retrieve the world matrix
 - `relativeTo` - The object, XR space, or reference space to cast rays from. This reference must be static in your scene.
 - `trackableType` - Optional parameter specifying what types of surfaces to hit test against
-
 
 ```tsx
 const matrixHelper = new Matrix4()
@@ -38,7 +38,7 @@ const hitTestPosition = new Vector3()
 
 function ContinuousHitTest() {
   const previewRef = useRef<Mesh>(null)
-  
+
   useXRHitTest(
     (results, getWorldMatrix) => {
       if (results.length === 0) return
@@ -55,7 +55,7 @@ function ContinuousHitTest() {
       previewRef.current.position.copy(hitTestPosition)
     }
   })
-  
+
   return (
       {/* Renders a sphere where the hit test intersects with the plane */}
       <mesh ref={previewRef} position={hitPosition}>
@@ -68,7 +68,7 @@ function ContinuousHitTest() {
 
 ## XRHitTest
 
-`XRHitTest` is a component that wraps the `useXRHitTest` hook. This makes it easier to add hit testing anywhere within your component tree. 
+`XRHitTest` is a component that wraps the `useXRHitTest` hook. This makes it easier to add hit testing anywhere within your component tree.
 
 ```tsx
 const matrixHelper = new Matrix4()
@@ -97,7 +97,7 @@ const store = createXRStore({
 
 `XRHitTest` has all of the same functionality as the `useXRHitTest` hook, just that it's built as a component.
 
-## useXRHitTestSource Hook 
+## useXRHitTestSource Hook
 
 The `useXRHitTestSource` hook provides lower-level access to hit test sources, giving you more control over when and how hit tests are performed. It is the same as the `useXRHitTest` hook, the only difference being that you have to manually check for hit test results; typically every frame, or every few frames.
 
@@ -106,6 +106,7 @@ The `useXRHitTestSource` hook provides lower-level access to hit test sources, g
 **When to use it:** In most cases you should use either `useXRHitTest` or `useXRRequestHitTest`, but you can use this hook when you have a static hit test source that you only want to occasionally perform constant hit tests from. Or if you want to recreate the `useXRHitTest` behavior manually.
 
 **Parameters:**
+
 - `relativeTo` - The object, XR space, or reference space to cast rays from
 - `trackableType` - Optional parameter specifying what types of surfaces to hit test against
 
@@ -117,7 +118,7 @@ function ManualHitTest() {
   const hitTestSource = useXRHitTestSource(meshRef)
   const [someCondition, setSomeCondition] = useState(false)
   const [hitResults, setHitResults] = useState<XRHitTestResult[]>([])
-  
+
   useFrame((_, __, frame: XRFrame | undefined) => {
     // Only perform hit testing when certain conditions are met
     if (frame && hitTestSource && someCondition) {
@@ -125,7 +126,7 @@ function ManualHitTest() {
       setHitResults(results)
     }
   })
-  
+
   return (
     <mesh ref={meshRef}>
       {/* Render hit test results. This will put spheres everywhere the hit test succeeds. In a real app don't use index as the key */}
@@ -159,23 +160,18 @@ The `useXRRequestHitTest` hook provides a function for one-time hit test request
 const matrixHelper = new Matrix4()
 function EventDrivenHitTest() {
   const requestHitTest = useXRRequestHitTest()
-  const meshRef = useRef<Mesh>(null)
   const [placedObjects, setPlacedObjects] = useState<Vector3[]>([])
-  
+
   const handleTap = async () => {
-    if (!meshRef.current) return
-    
-    try {
-      const results = await requestHitTest(meshRef, ['plane', 'mesh'])
-      if (results?.length > 0) {
-        const position = new Vector3().setFromMatrixPosition(matrixHelper)
-        setPlacedObjects(prev => [...prev, position])
-      }
-    } catch (error) {
-      console.error('Hit test failed:', error)
+    const hitTestResult = await requestHitTest('viewer', ['plane', 'mesh'])
+    const { results, getWorldMatrix } = hitTestResult
+    if (results?.length > 0) {
+      getWorldMatrix(matrixHelper, results[0])
+      const position = new Vector3().setFromMatrixPosition(matrixHelper)
+      setPlacedObjects((prev) => [...prev, position])
     }
   }
-  
+
   return (
     <>
       <IfInSessionMode allow={'immersive-ar'}>
@@ -183,7 +179,7 @@ function EventDrivenHitTest() {
           <button onClick={handleTap}>Place Object</button>
         </XRDomOverlay>
       </IfInSessionMode>
-      
+
       {/* Render placed objects */}
       {placedObjects.map((position, index) => (
         <mesh key={index} position={position}>
@@ -226,7 +222,7 @@ function ObjectPlacement() {
   const [placedObjects, setPlacedObjects] = useState<Vector3[]>([])
   const [previewPosition, setPreviewPosition] = useState<Vector3 | null>(null)
   const controllerRef = useRef<Group>(null)
-  
+
   // Continuous hit testing for preview
   useXRHitTest(
     (results, getWorldMatrix) => {
@@ -238,15 +234,15 @@ function ObjectPlacement() {
         setPreviewPosition(null)
       }
     },
-    'viewer' // Use viewer space for screen-based hit testing
+    'viewer', // Use viewer space for screen-based hit testing
   )
-  
+
   const placeObject = async () => {
     if (previewPosition) {
-      setPlacedObjects(prev => [...prev, previewPosition.clone()])
+      setPlacedObjects((prev) => [...prev, previewPosition.clone()])
     }
   }
-  
+
   return (
     <>
       {/* Preview object at hit test position */}
@@ -256,7 +252,7 @@ function ObjectPlacement() {
           <meshBasicMaterial color="yellow" transparent opacity={0.7} />
         </mesh>
       )}
-      
+
       {/* Placed objects */}
       {placedObjects.map((position, index) => (
         <mesh key={index} position={position}>
@@ -264,7 +260,7 @@ function ObjectPlacement() {
           <meshBasicMaterial color="green" />
         </mesh>
       ))}
-      
+
       {/* Placement trigger */}
       <IfInSessionMode allow={'immersive-ar'}>
         <XRDomOverlay>

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -1,10 +1,10 @@
 ---
 title: Hit Test
-description: How to add hit testing capabilities to your AR experiences?
+description: How to add hit testing capabilities to your AR experiences
 nav: 19
 ---
 
-Hit testing is a technique that allows developers to check for intersections with real-world geometry in AR experiences. `@react-three/xr` provides hooks and components for setting up hit testing. This tutorial covers all the hit testing hooks available in React Three XR and demonstrates how to use them effectively.
+Hit testing is a technique that allows developers to check for intersections with real-world surfaces in AR experiences. `@react-three/xr` provides hooks and components for setting up hit testing. This tutorial covers all the hit testing hooks available in React Three XR and demonstrates how to use them effectively.
 
 ## Overview of Hit Testing Components
 
@@ -16,11 +16,11 @@ React Three XR provides three hooks for hit testing:
 
 Additionally, React Three XR provides the `XRHitTest` component, which is a convenience wrapper for using the `useXRHitTest` hook to perform continuous hit testing.
 
-All rays cast by these components originate from the source's position and are cast in the direction that the source object is oriented (quaternion).
+All rays cast by these components originate from the source's position and are cast in the direction that the source object is oriented (quaternion; typically -z).
 
 ## useXRHitTest Hook
 
-The `useXRHitTest` hook is the most commonly used hook for hit testing. It automatically performs hit tests every frame and calls your callback function with the results.
+The `useXRHitTest` hook is the most commonly used hook for hit testing in the library. It automatically performs hit tests every frame and calls your callback function with the results.
 
 **What it does:** Sets up continuous hit testing that runs every frame, providing real-time intersection data with the real world.
 
@@ -86,15 +86,15 @@ const store = createXRStore({
 })
 ```
 
-It has all of the same functionality as the `useXRHitTest` hook, just that it's built as a component.
+`XRHitTest` has all of the same functionality as the `useXRHitTest` hook, just that it's built as a component.
 
-## useXRHitTestSource Hook // TODO: Add a toggle button to the ducks example that only performs a hit test on the right hand when toggled on
+## useXRHitTestSource Hook 
 
-The `useXRHitTestSource` hook provides lower-level access to hit test sources, giving you more control over when and how hit tests are performed.
+The `useXRHitTestSource` hook provides lower-level access to hit test sources, giving you more control over when and how hit tests are performed. It is similar to the `useXRRequestHitTest` hook in that you need to manually poll for hit test results. The only difference being that the source created by the `useXRHitTestSource` hook is more persistent than one created by `useXRRequestHitTest`.
 
-**What it does:** Creates and manages an XR hit test source that you can use to manually request hit test results.
+**What it does:** Does the same thing as the `useXRHitTest` hook, but does not automatically hit test every frame.
 
-**When to use it:** Use this when you need more granular control over hit testing, such as performing hit tests only under specific conditions, or when you want to manage the hit test lifecycle manually.
+**When to use it:** In most cases you should use either `useXRHitTest` or `useXRRequestHitTest`, but you can use this hook when you have a persistent hit test source that you only want to occasionally perform constant hit tests from. Or if you want to recreate the `useXRHitTest` behavior manually.
 
 **Parameters:**
 - `relativeTo` - The object, XR space, or reference space to cast rays from
@@ -135,7 +135,7 @@ function ManualHitTest() {
 }
 ```
 
-## useXRRequestHitTest Hook // TODO: Add a button to the controller to the ducks example that shows how far away the user's head is from the floor
+## useXRRequestHitTest Hook
 
 The `useXRRequestHitTest` hook provides a function for one-time hit test requests, perfect for event-driven hit testing.
 
@@ -146,6 +146,7 @@ The `useXRRequestHitTest` hook provides a function for one-time hit test request
 **Returns:** A function that takes the same parameters as other hit test hooks and returns a promise with hit test results
 
 ```tsx
+const matrixHelper = new Matrix4()
 function EventDrivenHitTest() {
   const requestHitTest = useXRRequestHitTest()
   const meshRef = useRef<Mesh>(null)
@@ -157,10 +158,7 @@ function EventDrivenHitTest() {
     try {
       const results = await requestHitTest(meshRef, ['plane', 'mesh'])
       if (results && results.length > 0) {
-        const matrix = new Matrix4()
-        // Note: You'll need to get the world matrix helper from the XR store
-        // This is a simplified example
-        const position = new Vector3().setFromMatrixPosition(matrix)
+        const position = new Vector3().setFromMatrixPosition(matrixHelper)
         setPlacedObjects(prev => [...prev, position])
       }
     } catch (error) {
@@ -264,19 +262,4 @@ function ObjectPlacement() {
 }
 ```
 
-With the `hitTestPosition` containing the world position of the last hit test, we can use it to create a 3d object and sync it to the object's position on every frame.
-
-```tsx
-function Point() {
-  const ref = useRef<Mesh>(null)
-  useFrame(() => ref.current?.position.copy(hitTestPosition))
-  return (
-    <mesh scale={0.05} ref={ref}>
-      <sphereGeometry />
-      <meshBasicMaterial />
-    </mesh>
-  )
-}
-```
-
-Alternatively, for devices that provide mesh detection, we can also add normal pointer event listeners to an XR Mesh to achieve the same behavior. Check out [this tutorial](./object-detection.md) for more information about mesh detection.
+Alternatively, for devices that provide mesh detection -- such as newer Meta Quest devices -- we can also add normal pointer event listeners to an XR Mesh to achieve the same behavior. Check out [this tutorial](./object-detection.md) for more information about mesh detection.

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -10,7 +10,7 @@ Hit testing is a technique that allows developers to check for intersections wit
 
 React Three XR provides three hooks for hit testing:
 
-- **`useXRHitTest`** - Continuous hit testing with automatic frame updates
+- **`useXRHitTest`** - Provides continuous hit testing with automatic frame updates
 - **`useXRHitTestSource`** - Lower-level hook for creating and managing hit test sources
 - **`useXRRequestHitTest`** - One-time hit test requests on demand
 
@@ -18,14 +18,14 @@ Additionally, React Three XR provides the `XRHitTest` component, which is a conv
 
 ## useXRHitTest Hook
 
-The `useXRHitTest` hook is the most commonly used hook for continuous hit testing. It automatically performs hit tests every frame and calls your callback function with the results.
+The `useXRHitTest` hook is the most commonly used hook for hit testing. It automatically performs hit tests every frame and calls your callback function with the results.
 
 **What it does:** Sets up continuous hit testing that runs every frame, providing real-time intersection data with the real world.
 
 **When to use it:** Use this when you need continuous tracking of where a ray intersects with real-world surfaces, such as for cursor positioning, object placement previews, or interactive AR elements.
 
 **Parameters:**
-- `fn` - Callback function that receives hit test results and a world matrix helper
+- `fn` - Callback function that receives hit test results and a function to retrieve the world matrix 
 - `relativeTo` - The object, XR space, or reference space to cast rays from
 - `trackableType` - Optional parameter specifying what types of surfaces to hit test against
 

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -4,8 +4,30 @@ description: How to add hit testing capabilities to your AR experiences?
 nav: 19
 ---
 
-Hit testing allows to check intersections with real-world geometry in AR experiences. `@react-three/xr` provides various hooks and components for setting up hit testing.
-The following example shows how to set up a hit test inside the right hand using the `XRHitTest` component, how to get the first hit test result using the `onResults` callback, and how to get the world position of that result into a vector.
+Hit testing allows to check intersections with real-world geometry in AR experiences. `@react-three/xr` provides various hooks and components for setting up hit testing. This tutorial covers all the hit testing hooks available in the library and demonstrates how to use them effectively.
+
+## Overview of Hit Testing Hooks
+
+The library provides three main hooks for hit testing:
+
+- **`useXRHitTest`** - Continuous hit testing with automatic frame updates
+- **`useXRHitTestSource`** - Lower-level hook for creating and managing hit test sources
+- **`useXRRequestHitTest`** - One-time hit test requests on demand
+
+## useXRHitTest Hook
+
+The `useXRHitTest` hook is the most commonly used hook for continuous hit testing. It automatically performs hit tests every frame and calls your callback function with the results.
+
+**What it does:** Sets up continuous hit testing that runs every frame, providing real-time intersection data with the real world.
+
+**When to use it:** Use this when you need continuous tracking of where a ray intersects with real-world surfaces, such as for cursor positioning, object placement previews, or interactive AR elements.
+
+**Parameters:**
+- `fn` - Callback function that receives hit test results and a world matrix helper
+- `relativeTo` - The object, XR space, or reference space to cast rays from
+- `trackableType` - Optional parameter specifying what types of surfaces to hit test against
+
+Here's the basic example using the `XRHitTest` component (which internally uses `useXRHitTest`):
 
 ```tsx
 const matrixHelper = new Matrix4()
@@ -33,6 +55,204 @@ const store = createXRStore({
     },
   },
 })
+```
+
+You can also use the hook directly in your components:
+
+```tsx
+function ContinuousHitTest() {
+  const meshRef = useRef<Mesh>(null)
+  const [hitPosition, setHitPosition] = useState<Vector3 | null>(null)
+  
+  useXRHitTest(
+    (results, getWorldMatrix) => {
+      if (results.length > 0) {
+        const matrix = new Matrix4()
+        getWorldMatrix(matrix, results[0])
+        const position = new Vector3().setFromMatrixPosition(matrix)
+        setHitPosition(position)
+      }
+    },
+    meshRef, // Cast rays from this mesh's position
+    'plane' // Only hit test against detected planes
+  )
+  
+  return <mesh ref={meshRef}>/* your mesh content */</mesh>
+}
+```
+
+## useXRHitTestSource Hook
+
+The `useXRHitTestSource` hook provides lower-level access to hit test sources, giving you more control over when and how hit tests are performed.
+
+**What it does:** Creates and manages an XR hit test source that you can use to manually request hit test results.
+
+**When to use it:** Use this when you need more granular control over hit testing, such as performing hit tests only under specific conditions, or when you want to manage the hit test lifecycle manually.
+
+**Parameters:**
+- `relativeTo` - The object, XR space, or reference space to cast rays from
+- `trackableType` - Optional parameter specifying what types of surfaces to hit test against
+
+**Returns:** A hit test source object that you can use with `frame.getHitTestResults()`
+
+```tsx
+function ManualHitTest() {
+  const meshRef = useRef<Mesh>(null)
+  const hitTestSource = useXRHitTestSource(meshRef, 'plane')
+  const [hitResults, setHitResults] = useState<XRHitTestResult[]>([])
+  
+  useFrame((_, __, frame: XRFrame | undefined) => {
+    // Only perform hit testing when certain conditions are met
+    if (frame && hitTestSource && someCondition) {
+      const results = frame.getHitTestResults(hitTestSource.source)
+      setHitResults(results)
+    }
+  })
+  
+  return (
+    <mesh ref={meshRef}>
+      {/* Render hit test results */}
+      {hitResults.map((result, index) => {
+        const matrix = new Matrix4()
+        hitTestSource?.getWorldMatrix(matrix, result)
+        const position = new Vector3().setFromMatrixPosition(matrix)
+        return (
+          <mesh key={index} position={position}>
+            <sphereGeometry args={[0.05]} />
+            <meshBasicMaterial color="red" />
+          </mesh>
+        )
+      })}
+    </mesh>
+  )
+}
+```
+
+## useXRRequestHitTest Hook
+
+The `useXRRequestHitTest` hook provides a function for one-time hit test requests, perfect for event-driven hit testing.
+
+**What it does:** Returns a function that can perform a single hit test request when called.
+
+**When to use it:** Use this for event-driven hit testing, such as when a user taps the screen, clicks a button, or performs a gesture. It's ideal for placing objects or checking intersections at specific moments.
+
+**Returns:** A function that takes the same parameters as other hit test hooks and returns a promise with hit test results
+
+```tsx
+function EventDrivenHitTest() {
+  const requestHitTest = useXRRequestHitTest()
+  const meshRef = useRef<Mesh>(null)
+  const [placedObjects, setPlacedObjects] = useState<Vector3[]>([])
+  
+  const handleTap = async () => {
+    if (!meshRef.current) return
+    
+    try {
+      const results = await requestHitTest(meshRef, ['plane', 'mesh'])
+      if (results && results.length > 0) {
+        const matrix = new Matrix4()
+        // Note: You'll need to get the world matrix helper from the XR store
+        // This is a simplified example
+        const position = new Vector3().setFromMatrixPosition(matrix)
+        setPlacedObjects(prev => [...prev, position])
+      }
+    } catch (error) {
+      console.error('Hit test failed:', error)
+    }
+  }
+  
+  return (
+    <>
+      <mesh ref={meshRef} onClick={handleTap}>
+        <boxGeometry />
+        <meshStandardMaterial />
+      </mesh>
+      
+      {/* Render placed objects */}
+      {placedObjects.map((position, index) => (
+        <mesh key={index} position={position}>
+          <sphereGeometry args={[0.1]} />
+          <meshBasicMaterial color="blue" />
+        </mesh>
+      ))}
+    </>
+  )
+}
+```
+
+## Trackable Types
+
+All hit testing hooks support specifying trackable types to control what surfaces the hit tests should target:
+
+- `'plane'` - Hit test against detected planes (floors, walls, tables)
+- `'point'` - Hit test against feature points in the environment
+- `'mesh'` - Hit test against detected meshes (requires mesh detection support)
+
+You can specify a single type or an array of types:
+
+```tsx
+// Single type
+useXRHitTest(callback, spaceRef, 'plane')
+
+// Multiple types
+useXRHitTest(callback, spaceRef, ['plane', 'mesh'])
+```
+
+## Practical Example: Object Placement
+
+Here's a complete example combining multiple hooks for a robust object placement system:
+
+```tsx
+function ObjectPlacement() {
+  const [placedObjects, setPlacedObjects] = useState<Vector3[]>([])
+  const [previewPosition, setPreviewPosition] = useState<Vector3 | null>(null)
+  const controllerRef = useRef<Group>(null)
+  
+  // Continuous hit testing for preview
+  useXRHitTest(
+    (results, getWorldMatrix) => {
+      if (results.length > 0) {
+        const matrix = new Matrix4()
+        getWorldMatrix(matrix, results[0])
+        const position = new Vector3().setFromMatrixPosition(matrix)
+        setPreviewPosition(position)
+      } else {
+        setPreviewPosition(null)
+      }
+    },
+    'viewer', // Use viewer space for screen-based hit testing
+    'plane'
+  )
+  
+  const placeObject = async () => {
+    if (previewPosition) {
+      setPlacedObjects(prev => [...prev, previewPosition.clone()])
+    }
+  }
+  
+  return (
+    <>
+      {/* Preview object at hit test position */}
+      {previewPosition && (
+        <mesh position={previewPosition}>
+          <sphereGeometry args={[0.05]} />
+          <meshBasicMaterial color="yellow" transparent opacity={0.7} />
+        </mesh>
+      )}
+      
+      {/* Placed objects */}
+      {placedObjects.map((position, index) => (
+        <mesh key={index} position={position}>
+          <sphereGeometry args={[0.05]} />
+          <meshBasicMaterial color="green" />
+        </mesh>
+      ))}
+      
+      {/* Placement trigger */}
+      <button onClick={placeObject}>Place Object</button>
+    </>
+  )
+}
 ```
 
 With the `hitTestPosition` containing the world position of the last hit test, we can use it to create a 3d object and sync it to the object's position on every frame.

--- a/docs/tutorials/hit-test.md
+++ b/docs/tutorials/hit-test.md
@@ -4,15 +4,17 @@ description: How to add hit testing capabilities to your AR experiences?
 nav: 19
 ---
 
-Hit testing allows to check intersections with real-world geometry in AR experiences. `@react-three/xr` provides various hooks and components for setting up hit testing. This tutorial covers all the hit testing hooks available in the library and demonstrates how to use them effectively.
+Hit testing is a technique that allows developers to check for intersections with real-world geometry in AR experiences. `@react-three/xr` provides hooks and components for setting up hit testing. This tutorial covers all the hit testing hooks available in React Three XR and demonstrates how to use them effectively.
 
 ## Overview of Hit Testing Hooks
 
-The library provides three main hooks for hit testing:
+React Three XR provides three hooks for hit testing:
 
 - **`useXRHitTest`** - Continuous hit testing with automatic frame updates
 - **`useXRHitTestSource`** - Lower-level hook for creating and managing hit test sources
 - **`useXRRequestHitTest`** - One-time hit test requests on demand
+
+Additionally, React Three XR provides the `XRHitTest` component, which is a convenience wrapper for using the `useXRHitTest` hook to perform continuous hit testing.
 
 ## useXRHitTest Hook
 
@@ -270,4 +272,4 @@ function Point() {
 }
 ```
 
-Alternatively, for devices that provide mesh detection, we can also add normal pointer events listeners to the XR Mesh to achieve the same behavior. Check out [this tutorial](./object-detection.md) for more information about mesh detection.
+Alternatively, for devices that provide mesh detection, we can also add normal pointer event listeners to an XR Mesh to achieve the same behavior. Check out [this tutorial](./object-detection.md) for more information about mesh detection.

--- a/examples/hit-testing/index.tsx
+++ b/examples/hit-testing/index.tsx
@@ -1,6 +1,7 @@
 import { StrictMode } from 'react'
 import { createRoot } from 'react-dom/client'
 import { App } from './src/app.js'
+import './style.css'
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>

--- a/examples/hit-testing/package.json
+++ b/examples/hit-testing/package.json
@@ -1,7 +1,9 @@
 {
   "name": "hit-testing",
   "dependencies": {
-    "@react-three/xr": "workspace:~"
+    "@react-three/uikit": "^0.8.21",
+    "@react-three/xr": "workspace:~",
+    "@react-three/handle": "workspace:~"
   },
   "scripts": {
     "dev": "vite --host",

--- a/examples/hit-testing/src/app.tsx
+++ b/examples/hit-testing/src/app.tsx
@@ -9,10 +9,10 @@ import { Duck } from './duck.js'
 import { Ducks } from './ducks.js'
 import { HitTest } from './hit-test.js'
 
-export let hitTestMatrices: Partial<Record<XRHandedness, Matrix4 | undefined>> = {}
+export let hitTestMatrices: Partial<Record<XRHandedness | 'duck', Matrix4 | undefined>> = {}
 
 export function onResults(
-  handedness: XRHandedness,
+  handedness: XRHandedness | 'duck',
   results: Array<XRHitTestResult>,
   getWorldMatrix: (target: Matrix4, hit: XRHitTestResult) => void,
 ) {

--- a/examples/hit-testing/src/app.tsx
+++ b/examples/hit-testing/src/app.tsx
@@ -6,12 +6,12 @@ import {
   IfInSessionMode,
   useXRInputSourceStateContext,
   XR,
-  XRDomOverlay,
   XRHitTest,
   XRSpace,
 } from '@react-three/xr'
 import { Suspense } from 'react'
 import { Matrix4 } from 'three'
+import { DomOverlay } from './dom-overlay.js'
 import { Duck } from './duck.js'
 import { Ducks } from './ducks.js'
 import { HitTest } from './hit-test.js'
@@ -55,12 +55,16 @@ const xr_store = createXRStore({
     // eslint-disable-next-line react-hooks/rules-of-hooks
     const state = useXRInputSourceStateContext()
 
+    const isLeftHanded = state.inputSource.handedness === 'left'
+
     return (
       <>
         <DefaultXRController />
-        <XRSpace space={state.inputSource.targetRaySpace}>
-          <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
-        </XRSpace>
+        {isLeftHanded && (
+          <XRSpace space={state.inputSource.targetRaySpace}>
+            <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
+          </XRSpace>
+        )}
       </>
     )
   },
@@ -79,10 +83,7 @@ export function App() {
           <IfInSessionMode allow={'immersive-ar'}>
             <HitTest />
             <Ducks />
-
-            <XRDomOverlay>
-              <button onClick={() => xr_store.getState().session?.end()}>Exit AR</button>
-            </XRDomOverlay>
+            <DomOverlay />
           </IfInSessionMode>
 
           <IfInSessionMode deny={'immersive-ar'}>

--- a/examples/hit-testing/src/app.tsx
+++ b/examples/hit-testing/src/app.tsx
@@ -1,16 +1,9 @@
 import { Canvas } from '@react-three/fiber'
-import {
-  createXRStore,
-  DefaultXRController,
-  DefaultXRHand,
-  IfInSessionMode,
-  useXRInputSourceStateContext,
-  XR,
-  XRHitTest,
-  XRSpace,
-} from '@react-three/xr'
+import { createXRStore, IfInSessionMode, XR } from '@react-three/xr'
 import { Suspense } from 'react'
 import { Matrix4 } from 'three'
+import { CustomController } from './custom-controller.js'
+import { CustomHand } from './custom-hand.js'
 import { DomOverlay } from './dom-overlay.js'
 import { Duck } from './duck.js'
 import { Ducks } from './ducks.js'
@@ -36,38 +29,8 @@ const xr_store = createXRStore({
   layers: false,
   meshDetection: false,
   planeDetection: false,
-
-  hand: () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const state = useXRInputSourceStateContext()
-
-    return (
-      <>
-        <DefaultXRHand />
-        <XRSpace space={state.inputSource.targetRaySpace}>
-          <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
-        </XRSpace>
-      </>
-    )
-  },
-
-  controller: () => {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
-    const state = useXRInputSourceStateContext()
-
-    const isLeftHanded = state.inputSource.handedness === 'left'
-
-    return (
-      <>
-        <DefaultXRController />
-        {isLeftHanded && (
-          <XRSpace space={state.inputSource.targetRaySpace}>
-            <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
-          </XRSpace>
-        )}
-      </>
-    )
-  },
+  hand: CustomHand,
+  controller: CustomController,
 })
 
 export function App() {

--- a/examples/hit-testing/src/app.tsx
+++ b/examples/hit-testing/src/app.tsx
@@ -9,10 +9,10 @@ import { Duck } from './duck.js'
 import { Ducks } from './ducks.js'
 import { HitTest } from './hit-test.js'
 
-export let hitTestMatrices: Partial<Record<XRHandedness | 'duck', Matrix4 | undefined>> = {}
+export let hitTestMatrices: Partial<Record<XRHandedness, Matrix4 | undefined>> = {}
 
 export function onResults(
-  handedness: XRHandedness | 'duck',
+  handedness: XRHandedness,
   results: Array<XRHitTestResult>,
   getWorldMatrix: (target: Matrix4, hit: XRHitTestResult) => void,
 ) {

--- a/examples/hit-testing/src/custom-controller.tsx
+++ b/examples/hit-testing/src/custom-controller.tsx
@@ -4,60 +4,94 @@ import {
   DefaultXRController,
   XRHitTest,
   XRSpace,
+  useXRHitTestSource,
   useXRInputSourceState,
   useXRInputSourceStateContext,
 } from '@react-three/xr'
 import { useRef, useState } from 'react'
-import { onResults } from './app.js'
+import { Group } from 'three'
+import { hitTestMatrices, onResults } from './app.js'
 import { useTestDistanceToFloor } from './useTestDistanceToFloor.js'
 
-const defaultControllerMessage = 'Press the A button to test distance to floor'
+const defaultRightControllerMessage = 'Press the A button to test distance to floor'
 export const CustomController = () => {
-  const [controllerText, setControllerText] = useState<string>(defaultControllerMessage)
-  const isPressed = useRef<boolean>(false)
+  const [rightControllerText, setRightControllerText] = useState<string>(defaultRightControllerMessage)
+  const [leftControllerPlacementEnabled, setLeftControllerPlacementEnabled] = useState<boolean>(false)
+  const leftControllerRayRef = useRef<Group>(null)
+  const isAPressed = useRef<boolean>(false)
+  const isXPressed = useRef<boolean>(false)
   const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const testDistance = useTestDistanceToFloor()
 
+  const leftControllerHitTestSource = useXRHitTestSource(leftControllerRayRef)
+
   const state = useXRInputSourceStateContext()
   const rightController = useXRInputSourceState('controller', 'right')
+  const leftController = useXRInputSourceState('controller', 'left')
   const isRightHand = state.inputSource.handedness === 'right'
 
-  useFrame(() => {
-    if (rightController?.gamepad?.['a-button']?.state === 'pressed' && !isPressed.current) {
+  useFrame((_, __, frame) => {
+    // Button press handling **********************
+    if (rightController?.gamepad?.['a-button']?.state === 'pressed' && !isAPressed.current) {
+      isAPressed.current = true
       testDistance().then((result) => {
         if (result !== undefined) {
-          setControllerText(`Distance to Floor: ${result.toFixed(2)} meters`)
+          setRightControllerText(`Distance to Floor: ${result.toFixed(2)} meters`)
         } else {
-          setControllerText('Unable to calculate distance. Try looking towards the floor.')
+          setRightControllerText('Unable to calculate distance. Try looking towards the floor.')
         }
 
         if (timeoutRef.current) {
           clearTimeout(timeoutRef.current)
         }
         timeoutRef.current = setTimeout(() => {
-          setControllerText(defaultControllerMessage)
+          setRightControllerText(defaultRightControllerMessage)
         }, 5000)
       })
-      isPressed.current = true
+    }
+
+    if (leftController?.gamepad?.['x-button']?.state === 'pressed' && !isXPressed.current) {
+      isXPressed.current = true
+      setLeftControllerPlacementEnabled((x) => {
+        const newValue = !x
+        if (!newValue) {
+          hitTestMatrices['left'] = undefined
+        }
+        return newValue
+      })
+    }
+
+    if (leftController?.gamepad?.['x-button']?.state === 'default') {
+      isXPressed.current = false
     }
 
     if (rightController?.gamepad?.['a-button']?.state === 'default') {
-      isPressed.current = false
+      isAPressed.current = false
+    }
+
+    // Conditional Hit-test handling**********************
+    if (frame && leftControllerPlacementEnabled && leftControllerHitTestSource) {
+      const results = frame.getHitTestResults(leftControllerHitTestSource.source)
+      onResults('left', results, leftControllerHitTestSource.getWorldMatrix)
     }
   })
+
+  const leftControllerText = `Press the X button to ${leftControllerPlacementEnabled ? 'disable' : 'enable'} placing with the left controller`
 
   return (
     <>
       <DefaultXRController />
-      {isRightHand && (
-        <Root transformTranslateY={-2.9} transformRotateX={-25}>
-          <Text fontSize={2} color={'white'}>
-            {controllerText}
-          </Text>
-        </Root>
-      )}
+      <Root transformTranslateY={-2.9} transformRotateX={-25}>
+        <Text fontSize={2} color={'white'}>
+          {isRightHand ? rightControllerText : leftControllerText}
+        </Text>
+      </Root>
       <XRSpace space={state.inputSource.targetRaySpace}>
-        <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
+        {isRightHand ? (
+          <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
+        ) : (
+          <group ref={leftControllerRayRef} />
+        )}
       </XRSpace>
     </>
   )

--- a/examples/hit-testing/src/custom-controller.tsx
+++ b/examples/hit-testing/src/custom-controller.tsx
@@ -1,4 +1,5 @@
 import { useFrame } from '@react-three/fiber'
+import { Root, Text } from '@react-three/uikit'
 import {
   DefaultXRController,
   XRHitTest,
@@ -6,29 +7,58 @@ import {
   useXRInputSourceState,
   useXRInputSourceStateContext,
 } from '@react-three/xr'
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { onResults } from './app.js'
+import { useTestDistanceToFloor } from './useTestDistanceToFloor.js'
 
+const defaultControllerMessage = 'Press the A button to test distance to floor'
 export const CustomController = () => {
-  const [allowRightHandHitTesting, setAllowRightHandHitTesting] = useState(false)
+  const [controllerText, setControllerText] = useState<string>(defaultControllerMessage)
+  const isPressed = useRef<boolean>(false)
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
+  const testDistance = useTestDistanceToFloor()
+
   const state = useXRInputSourceStateContext()
   const rightController = useXRInputSourceState('controller', 'right')
-  const isLeftHanded = state.inputSource.handedness === 'left'
+  const isRightHand = state.inputSource.handedness === 'right'
 
   useFrame(() => {
-    if (rightController?.gamepad?.['a-button']?.state === 'pressed') {
-      setAllowRightHandHitTesting((prev) => !prev)
+    if (rightController?.gamepad?.['a-button']?.state === 'pressed' && !isPressed.current) {
+      testDistance().then((result) => {
+        if (result !== undefined) {
+          setControllerText(`Distance to Floor: ${result.toFixed(2)} meters`)
+        } else {
+          setControllerText('Unable to calculate distance. Try looking towards the floor.')
+        }
+
+        if (timeoutRef.current) {
+          clearTimeout(timeoutRef.current)
+        }
+        timeoutRef.current = setTimeout(() => {
+          setControllerText(defaultControllerMessage)
+        }, 5000)
+      })
+      isPressed.current = true
+    }
+
+    if (rightController?.gamepad?.['a-button']?.state === 'default') {
+      isPressed.current = false
     }
   })
 
   return (
     <>
       <DefaultXRController />
-      {(isLeftHanded || allowRightHandHitTesting) && (
-        <XRSpace space={state.inputSource.targetRaySpace}>
-          <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
-        </XRSpace>
+      {isRightHand && (
+        <Root transformTranslateY={-2.9} transformRotateX={-25}>
+          <Text fontSize={2} color={'white'}>
+            {controllerText}
+          </Text>
+        </Root>
       )}
+      <XRSpace space={state.inputSource.targetRaySpace}>
+        <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
+      </XRSpace>
     </>
   )
 }

--- a/examples/hit-testing/src/custom-controller.tsx
+++ b/examples/hit-testing/src/custom-controller.tsx
@@ -1,0 +1,34 @@
+import { useFrame } from '@react-three/fiber'
+import {
+  DefaultXRController,
+  XRHitTest,
+  XRSpace,
+  useXRInputSourceState,
+  useXRInputSourceStateContext,
+} from '@react-three/xr'
+import { useState } from 'react'
+import { onResults } from './app.js'
+
+export const CustomController = () => {
+  const [allowRightHandHitTesting, setAllowRightHandHitTesting] = useState(false)
+  const state = useXRInputSourceStateContext()
+  const rightController = useXRInputSourceState('controller', 'right')
+  const isLeftHanded = state.inputSource.handedness === 'left'
+
+  useFrame(() => {
+    if (rightController?.gamepad?.['a-button']?.state === 'pressed') {
+      setAllowRightHandHitTesting((prev) => !prev)
+    }
+  })
+
+  return (
+    <>
+      <DefaultXRController />
+      {(isLeftHanded || allowRightHandHitTesting) && (
+        <XRSpace space={state.inputSource.targetRaySpace}>
+          <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
+        </XRSpace>
+      )}
+    </>
+  )
+}

--- a/examples/hit-testing/src/custom-hand.tsx
+++ b/examples/hit-testing/src/custom-hand.tsx
@@ -1,0 +1,15 @@
+import { DefaultXRHand, XRHitTest, XRSpace, useXRInputSourceStateContext } from '@react-three/xr'
+import { onResults } from './app.js'
+
+export const CustomHand = () => {
+  const state = useXRInputSourceStateContext()
+
+  return (
+    <>
+      <DefaultXRHand />
+      <XRSpace space={state.inputSource.targetRaySpace}>
+        <XRHitTest onResults={onResults.bind(null, state.inputSource.handedness)} />
+      </XRSpace>
+    </>
+  )
+}

--- a/examples/hit-testing/src/dom-overlay.tsx
+++ b/examples/hit-testing/src/dom-overlay.tsx
@@ -1,28 +1,41 @@
 import { useXRStore, XRDomOverlay } from '@react-three/xr'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useTestDistanceToFloor } from './useTestDistanceToFloor.js'
 
 export const DomOverlay = () => {
-  const [distance, setDistance] = useState<string>('')
+  const [distanceMessage, setDistanceMessage] = useState<string>('')
+  const timeoutRef = useRef<NodeJS.Timeout | null>(null)
   const testDistanceToFloor = useTestDistanceToFloor()
   const xr_store = useXRStore()
+
+  const showMessageWithTimeout = (message: string) => {
+    setDistanceMessage(message)
+    if (timeoutRef.current) {
+      clearTimeout(timeoutRef.current)
+    }
+    timeoutRef.current = setTimeout(() => {
+      setDistanceMessage('')
+      timeoutRef.current = null
+    }, 5000)
+  }
 
   const onTestDistanceToFloorClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
     const distance = await testDistanceToFloor()
     console.log('distance:', distance)
-    if (distance !== undefined) {
-      setDistance(`Distance to floor: ${distance.toFixed(2)} meters`)
-      setTimeout(() => {
-        setDistance('')
-      }, 5000)
-    }
+
+    distance !== undefined
+      ? showMessageWithTimeout(`Distance to floor: ${distance.toFixed(2)} meters`)
+      : showMessageWithTimeout('Unable to calculate distance. Try looking towards the floor.')
+
     e.stopPropagation()
   }
 
   return (
     <XRDomOverlay>
-      <h1 className={'distanceMessage'}>{distance}</h1>
-      <button onClick={() => xr_store.getState().session?.end()}>Exit AR</button>
+      <span className={'distanceMessage'}>{distanceMessage}</span>
+      <button className={'exitAR'} onClick={() => xr_store.getState().session?.end()}>
+        Exit AR
+      </button>
       <button className={'testDistanceToFloor'} onClick={onTestDistanceToFloorClick}>
         Test Distance to Floor
       </button>

--- a/examples/hit-testing/src/dom-overlay.tsx
+++ b/examples/hit-testing/src/dom-overlay.tsx
@@ -1,0 +1,31 @@
+import { useXRStore, XRDomOverlay } from '@react-three/xr'
+import { useState } from 'react'
+import { useTestDistanceToFloor } from './useTestDistanceToFloor.js'
+
+export const DomOverlay = () => {
+  const [distance, setDistance] = useState<string>('')
+  const testDistanceToFloor = useTestDistanceToFloor()
+  const xr_store = useXRStore()
+
+  const onTestDistanceToFloorClick = async (e: React.MouseEvent<HTMLButtonElement>) => {
+    const distance = await testDistanceToFloor()
+    console.log('distance:', distance)
+    if (distance !== undefined) {
+      setDistance(`Distance to floor: ${distance.toFixed(2)} meters`)
+      setTimeout(() => {
+        setDistance('')
+      }, 5000)
+    }
+    e.stopPropagation()
+  }
+
+  return (
+    <XRDomOverlay>
+      <h1 className={'distanceMessage'}>{distance}</h1>
+      <button onClick={() => xr_store.getState().session?.end()}>Exit AR</button>
+      <button className={'testDistanceToFloor'} onClick={onTestDistanceToFloorClick}>
+        Test Distance to Floor
+      </button>
+    </XRDomOverlay>
+  )
+}

--- a/examples/hit-testing/src/duck.tsx
+++ b/examples/hit-testing/src/duck.tsx
@@ -8,12 +8,7 @@
  */
 import { useGLTF } from '@react-three/drei'
 import { useFrame } from '@react-three/fiber'
-import { Handle, HandleStore } from '@react-three/handle'
-import { useXRRequestHitTest } from '@react-three/xr'
-import { useRef, useState } from 'react'
 import { Group } from 'three'
-import { onResults } from './app.js'
-import { Reticle } from './reticle.js'
 
 // const MODEL = 'https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/duck/model.gltf'
 const MODEL = 'duck.gltf'
@@ -22,38 +17,9 @@ useGLTF.preload(MODEL)
 
 export const Duck = (props: any) => {
   const { nodes, materials } = useGLTF(MODEL) as any
-  const [isBeingGrabbed, setisBeingGrabbed] = useState(false)
-  const hitTestRefPoint = useRef<Group>(null)
-  const duckGroup = useRef<Group>(null)
-  const hitTestRequest = useXRRequestHitTest()
-  const handleRef = useRef<HandleStore<unknown>>(null)
-
-  useFrame(async (_, __, frame: XRFrame | undefined) => {
-    if (frame && isBeingGrabbed && hitTestRefPoint.current) {
-      const requestedHitTest = await hitTestRequest(hitTestRefPoint)
-      if (requestedHitTest?.results && requestedHitTest.results.length > 0 && requestedHitTest?.getWorldMatrix) {
-        onResults('duck', requestedHitTest?.results ?? [], requestedHitTest?.getWorldMatrix)
-      }
-    }
-  })
 
   return (
-    <>
-      <group ref={duckGroup} {...props} dispose={null}>
-        <Handle
-          ref={handleRef}
-          handleRef={duckGroup}
-          apply={(state) => {
-            if (state.last) {
-              setisBeingGrabbed(false)
-            } else {
-              setisBeingGrabbed(true)
-            }
-
-            duckGroup.current?.position.copy(state.current.position)
-            duckGroup.current?.quaternion.copy(state.current.quaternion)
-          }}
-        >
+      <group {...props} dispose={null}>
           <mesh
             geometry={nodes.character_duck.geometry}
             material={nodes.character_duck.material}
@@ -76,10 +42,6 @@ export const Duck = (props: any) => {
               <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
             </group>
           </mesh>
-          <group ref={hitTestRefPoint} />
-        </Handle>
       </group>
-      {isBeingGrabbed && <Reticle handedness="duck" />}
-    </>
   )
 }

--- a/examples/hit-testing/src/duck.tsx
+++ b/examples/hit-testing/src/duck.tsx
@@ -9,7 +9,7 @@
 import { useGLTF } from '@react-three/drei'
 import { useFrame } from '@react-three/fiber'
 import { Handle, HandleStore } from '@react-three/handle'
-import { useXRHitTestSource } from '@react-three/xr'
+import { useXRRequestHitTest } from '@react-three/xr'
 import { useRef, useState } from 'react'
 import { Group } from 'three'
 import { onResults } from './app.js'
@@ -25,62 +25,61 @@ export const Duck = (props: any) => {
   const [isBeingGrabbed, setisBeingGrabbed] = useState(false)
   const hitTestRefPoint = useRef<Group>(null)
   const duckGroup = useRef<Group>(null)
-  const hitTestSource = useXRHitTestSource(hitTestRefPoint, 'plane')
+  const hitTestRequest = useXRRequestHitTest()
   const handleRef = useRef<HandleStore<unknown>>(null)
 
-  useFrame((_, __, frame: XRFrame | undefined) => {
-    if (frame && hitTestSource && isBeingGrabbed) {
-      const hitTestResults = frame.getHitTestResults(hitTestSource.source)
-      onResults('duck', hitTestResults, hitTestSource.getWorldMatrix)
+  useFrame(async (_, __, frame: XRFrame | undefined) => {
+    if (frame && isBeingGrabbed && hitTestRefPoint.current) {
+      const requestedHitTest = await hitTestRequest(hitTestRefPoint)
+      if (requestedHitTest?.results && requestedHitTest.results.length > 0 && requestedHitTest?.getWorldMatrix) {
+        onResults('duck', requestedHitTest?.results ?? [], requestedHitTest?.getWorldMatrix)
+      }
     }
   })
 
   return (
-    <group ref={duckGroup} {...props} dispose={null}>
-      <Handle
-        ref={handleRef}
-        handleRef={duckGroup}
-        apply={(state) => {
-          if (state.last) {
-            setisBeingGrabbed(false)
-          } else {
-            setisBeingGrabbed(true)
-          }
+    <>
+      <group ref={duckGroup} {...props} dispose={null}>
+        <Handle
+          ref={handleRef}
+          handleRef={duckGroup}
+          apply={(state) => {
+            if (state.last) {
+              setisBeingGrabbed(false)
+            } else {
+              setisBeingGrabbed(true)
+            }
 
-          duckGroup.current?.position.copy(state.current.position)
-          duckGroup.current?.quaternion.copy(state.current.quaternion)
-        }}
-      >
-        <mesh
-          geometry={nodes.character_duck.geometry}
-          material={nodes.character_duck.material}
-          rotation={[Math.PI / 2, 0, 0]}
+            duckGroup.current?.position.copy(state.current.position)
+            duckGroup.current?.quaternion.copy(state.current.quaternion)
+          }}
         >
           <mesh
-            geometry={nodes.character_duckArmLeft.geometry}
-            material={nodes.character_duckArmLeft.material}
-            position={[0.2, 0, -0.63]}
-          />
-          <mesh
-            geometry={nodes.character_duckArmRight.geometry}
-            material={nodes.character_duckArmRight.material}
-            position={[-0.2, 0, -0.63]}
-          />
+            geometry={nodes.character_duck.geometry}
+            material={nodes.character_duck.material}
+            rotation={[Math.PI / 2, 0, 0]}
+          >
+            <mesh
+              geometry={nodes.character_duckArmLeft.geometry}
+              material={nodes.character_duckArmLeft.material}
+              position={[0.2, 0, -0.63]}
+            />
+            <mesh
+              geometry={nodes.character_duckArmRight.geometry}
+              material={nodes.character_duckArmRight.material}
+              position={[-0.2, 0, -0.63]}
+            />
 
-          <group position={[0, 0, -0.7]}>
-            <mesh geometry={nodes.Cube1338.geometry} material={nodes.Cube1338.material} />
-            <mesh geometry={nodes.Cube1338_1.geometry} material={materials['Yellow.043']} />
-            <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
-          </group>
-        </mesh>
-        <group ref={hitTestRefPoint}>
-          <mesh position={[0, -0.5, 0]}>
-            <cylinderGeometry args={[0.01, 0.01, 1, 8]} />
-            <meshBasicMaterial color="red" />
+            <group position={[0, 0, -0.7]}>
+              <mesh geometry={nodes.Cube1338.geometry} material={nodes.Cube1338.material} />
+              <mesh geometry={nodes.Cube1338_1.geometry} material={materials['Yellow.043']} />
+              <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
+            </group>
           </mesh>
-        </group>
-        {isBeingGrabbed && <Reticle handedness="duck" />}
-      </Handle>
-    </group>
+          <group ref={hitTestRefPoint} />
+        </Handle>
+      </group>
+      {isBeingGrabbed && <Reticle handedness="duck" />}
+    </>
   )
 }

--- a/examples/hit-testing/src/duck.tsx
+++ b/examples/hit-testing/src/duck.tsx
@@ -7,6 +7,13 @@
  * license: CC0
  */
 import { useGLTF } from '@react-three/drei'
+import { useFrame } from '@react-three/fiber'
+import { Handle, HandleStore } from '@react-three/handle'
+import { useXRHitTestSource } from '@react-three/xr'
+import { useRef, useState } from 'react'
+import { Group } from 'three'
+import { onResults } from './app.js'
+import { Reticle } from './reticle.js'
 
 // const MODEL = 'https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/duck/model.gltf'
 const MODEL = 'duck.gltf'
@@ -15,31 +22,65 @@ useGLTF.preload(MODEL)
 
 export const Duck = (props: any) => {
   const { nodes, materials } = useGLTF(MODEL) as any
+  const [isBeingGrabbed, setisBeingGrabbed] = useState(false)
+  const hitTestRefPoint = useRef<Group>(null)
+  const duckGroup = useRef<Group>(null)
+  const hitTestSource = useXRHitTestSource(hitTestRefPoint, 'plane')
+  const handleRef = useRef<HandleStore<unknown>>(null)
+
+  useFrame((_, __, frame: XRFrame | undefined) => {
+    if (frame && hitTestSource && isBeingGrabbed) {
+      const hitTestResults = frame.getHitTestResults(hitTestSource.source)
+      onResults('duck', hitTestResults, hitTestSource.getWorldMatrix)
+    }
+  })
 
   return (
-    <group {...props} dispose={null}>
-      <mesh
-        geometry={nodes.character_duck.geometry}
-        material={nodes.character_duck.material}
-        rotation={[Math.PI / 2, 0, 0]}
+    <group ref={duckGroup} {...props} dispose={null}>
+      <Handle
+        ref={handleRef}
+        handleRef={duckGroup}
+        apply={(state) => {
+          if (state.last) {
+            setisBeingGrabbed(false)
+          } else {
+            setisBeingGrabbed(true)
+          }
+
+          duckGroup.current?.position.copy(state.current.position)
+          duckGroup.current?.quaternion.copy(state.current.quaternion)
+        }}
       >
         <mesh
-          geometry={nodes.character_duckArmLeft.geometry}
-          material={nodes.character_duckArmLeft.material}
-          position={[0.2, 0, -0.63]}
-        />
-        <mesh
-          geometry={nodes.character_duckArmRight.geometry}
-          material={nodes.character_duckArmRight.material}
-          position={[-0.2, 0, -0.63]}
-        />
+          geometry={nodes.character_duck.geometry}
+          material={nodes.character_duck.material}
+          rotation={[Math.PI / 2, 0, 0]}
+        >
+          <mesh
+            geometry={nodes.character_duckArmLeft.geometry}
+            material={nodes.character_duckArmLeft.material}
+            position={[0.2, 0, -0.63]}
+          />
+          <mesh
+            geometry={nodes.character_duckArmRight.geometry}
+            material={nodes.character_duckArmRight.material}
+            position={[-0.2, 0, -0.63]}
+          />
 
-        <group position={[0, 0, -0.7]}>
-          <mesh geometry={nodes.Cube1338.geometry} material={nodes.Cube1338.material} />
-          <mesh geometry={nodes.Cube1338_1.geometry} material={materials['Yellow.043']} />
-          <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
+          <group position={[0, 0, -0.7]}>
+            <mesh geometry={nodes.Cube1338.geometry} material={nodes.Cube1338.material} />
+            <mesh geometry={nodes.Cube1338_1.geometry} material={materials['Yellow.043']} />
+            <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
+          </group>
+        </mesh>
+        <group ref={hitTestRefPoint}>
+          <mesh position={[0, -0.5, 0]}>
+            <cylinderGeometry args={[0.01, 0.01, 1, 8]} />
+            <meshBasicMaterial color="red" />
+          </mesh>
         </group>
-      </mesh>
+        {isBeingGrabbed && <Reticle handedness="duck" />}
+      </Handle>
     </group>
   )
 }

--- a/examples/hit-testing/src/duck.tsx
+++ b/examples/hit-testing/src/duck.tsx
@@ -7,8 +7,6 @@
  * license: CC0
  */
 import { useGLTF } from '@react-three/drei'
-import { useFrame } from '@react-three/fiber'
-import { Group } from 'three'
 
 // const MODEL = 'https://vazxmixjsiawhamofees.supabase.co/storage/v1/object/public/models/duck/model.gltf'
 const MODEL = 'duck.gltf'
@@ -19,29 +17,29 @@ export const Duck = (props: any) => {
   const { nodes, materials } = useGLTF(MODEL) as any
 
   return (
-      <group {...props} dispose={null}>
-          <mesh
-            geometry={nodes.character_duck.geometry}
-            material={nodes.character_duck.material}
-            rotation={[Math.PI / 2, 0, 0]}
-          >
-            <mesh
-              geometry={nodes.character_duckArmLeft.geometry}
-              material={nodes.character_duckArmLeft.material}
-              position={[0.2, 0, -0.63]}
-            />
-            <mesh
-              geometry={nodes.character_duckArmRight.geometry}
-              material={nodes.character_duckArmRight.material}
-              position={[-0.2, 0, -0.63]}
-            />
+    <group {...props} dispose={null}>
+      <mesh
+        geometry={nodes.character_duck.geometry}
+        material={nodes.character_duck.material}
+        rotation={[Math.PI / 2, 0, 0]}
+      >
+        <mesh
+          geometry={nodes.character_duckArmLeft.geometry}
+          material={nodes.character_duckArmLeft.material}
+          position={[0.2, 0, -0.63]}
+        />
+        <mesh
+          geometry={nodes.character_duckArmRight.geometry}
+          material={nodes.character_duckArmRight.material}
+          position={[-0.2, 0, -0.63]}
+        />
 
-            <group position={[0, 0, -0.7]}>
-              <mesh geometry={nodes.Cube1338.geometry} material={nodes.Cube1338.material} />
-              <mesh geometry={nodes.Cube1338_1.geometry} material={materials['Yellow.043']} />
-              <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
-            </group>
-          </mesh>
-      </group>
+        <group position={[0, 0, -0.7]}>
+          <mesh geometry={nodes.Cube1338.geometry} material={nodes.Cube1338.material} />
+          <mesh geometry={nodes.Cube1338_1.geometry} material={materials['Yellow.043']} />
+          <mesh geometry={nodes.Cube1338_2.geometry} material={materials['Black.027']} />
+        </group>
+      </mesh>
+    </group>
   )
 }

--- a/examples/hit-testing/src/ducks.tsx
+++ b/examples/hit-testing/src/ducks.tsx
@@ -22,7 +22,6 @@ export const Ducks = () => {
         setDucks((ducks) => [...ducks, { position, quaternion }])
       }
     },
-
     [],
   )
 

--- a/examples/hit-testing/src/reticle.tsx
+++ b/examples/hit-testing/src/reticle.tsx
@@ -13,13 +13,13 @@ const ReticleMesh = forwardRef<Mesh, ThreeElements['mesh']>((props, ref) => {
 
   return (
     <mesh ref={ref} geometry={geometry_merged} {...props}>
-      <meshBasicMaterial side={THREE.DoubleSide} color={props.color} />
+      <meshBasicMaterial side={THREE.DoubleSide} />
     </mesh>
   )
 })
 
 export const Reticle = memo(({ handedness }: { handedness: XRHandedness | 'duck' }) => {
-  const ref = useRef<Mesh>(undefined)
+  const ref = useRef<Mesh>(null)
 
   useFrame(() => {
     if (ref.current == null) {

--- a/examples/hit-testing/src/reticle.tsx
+++ b/examples/hit-testing/src/reticle.tsx
@@ -18,7 +18,7 @@ const ReticleMesh = forwardRef<Mesh, ThreeElements['mesh']>((props, ref) => {
   )
 })
 
-export const Reticle = memo(({ handedness }: { handedness: XRHandedness | 'duck' }) => {
+export const Reticle = memo(({ handedness }: { handedness: XRHandedness }) => {
   const ref = useRef<Mesh>(null)
 
   useFrame(() => {

--- a/examples/hit-testing/src/reticle.tsx
+++ b/examples/hit-testing/src/reticle.tsx
@@ -18,7 +18,7 @@ const ReticleMesh = forwardRef<Mesh, ThreeElements['mesh']>((props, ref) => {
   )
 })
 
-export const Reticle = memo(({ handedness }: { handedness: XRHandedness }) => {
+export const Reticle = memo(({ handedness }: { handedness: XRHandedness | 'duck' }) => {
   const ref = useRef<Mesh>(undefined)
 
   useFrame(() => {

--- a/examples/hit-testing/src/useTestDistanceToFloor.ts
+++ b/examples/hit-testing/src/useTestDistanceToFloor.ts
@@ -1,0 +1,54 @@
+import { Camera, useThree } from '@react-three/fiber'
+import { useXRRequestHitTest } from '@react-three/xr'
+import { useCallback } from 'react'
+import { Matrix4, Quaternion, Vector3 } from 'three'
+
+const matrixHelper = new Matrix4()
+const positionHelper = new Vector3()
+const quaternionHelper = new Quaternion()
+const scaleHelper = new Vector3()
+const cameraPositionHelper = new Vector3()
+
+const isCameraFacingDown = (camera: Camera) => {
+  // Get camera's forward direction
+  const forward = new Vector3(0, 0, -1).applyQuaternion(camera.quaternion)
+  // World down direction
+  const down = new Vector3(0, -1, 0)
+  // Dot product
+  const dot = forward.dot(down)
+  // If dot < 0.75, camera is NOT facing down
+  console.log('dot:', dot)
+  if (dot < 0.75) {
+    return false
+  }
+  return true
+}
+
+export const useTestDistanceToFloor = () => {
+  const requestHitTest = useXRRequestHitTest()
+  const camera = useThree().camera
+
+  const testDistanceToFloor = useCallback(async () => {
+    if (isCameraFacingDown(camera)) {
+      const hitTestResult = await requestHitTest('viewer', 'plane')
+      console.log('hitTestResult:', hitTestResult)
+      if (!hitTestResult) {
+        return undefined
+      }
+      const { results, getWorldMatrix } = hitTestResult
+
+      console.log('results:', results)
+      if (results && results.length > 0 && results[0]) {
+        getWorldMatrix(matrixHelper, results[0])
+        matrixHelper.decompose(positionHelper, quaternionHelper, scaleHelper)
+        camera.getWorldPosition(cameraPositionHelper)
+
+        const distanceToFloor = cameraPositionHelper.y - positionHelper.y
+        return distanceToFloor
+      }
+    }
+    return undefined
+  }, [camera, requestHitTest])
+
+  return testDistanceToFloor
+}

--- a/examples/hit-testing/src/useTestDistanceToFloor.ts
+++ b/examples/hit-testing/src/useTestDistanceToFloor.ts
@@ -30,8 +30,7 @@ export const useTestDistanceToFloor = () => {
 
   const testDistanceToFloor = useCallback(async () => {
     if (isCameraFacingDown(camera)) {
-      const hitTestResult = await requestHitTest('viewer', 'plane')
-      console.log('hitTestResult:', hitTestResult)
+      const hitTestResult = await requestHitTest('viewer')
       if (!hitTestResult) {
         return undefined
       }

--- a/examples/hit-testing/style.css
+++ b/examples/hit-testing/style.css
@@ -36,3 +36,31 @@ button {
   box-shadow: 0px 0px 20px rgba(0, 0, 0, 1);
   transform: translate(-50%, 0);
 }
+
+.distanceMessage {
+  position: absolute;
+  top: 1rem;
+  left: 50%;
+  transform: translateX(-50%);
+  color: white;
+  font-size: 2rem;
+  text-shadow: 0px 0px 20px rgba(0, 0, 0, 1);
+}
+
+.testDistanceToFloor {
+  position: absolute;
+  bottom: 2rem;
+  transform: none;
+  color: white;
+  font-size: 1rem;
+  right: 2rem;
+}
+
+.exitAR {
+  position: absolute;
+  bottom: 2rem;
+  transform: none;
+  left: 2rem;
+  color: white;
+  font-size: 1rem;
+}

--- a/packages/react/xr/plugins/pretty-md.mjs
+++ b/packages/react/xr/plugins/pretty-md.mjs
@@ -140,7 +140,7 @@ export const load = (app) => {
 
           // Update the nav number in the frontmatter
           const content = fs.readFileSync(targetFile, 'utf-8')
-          const updatedContent = content.replace(/nav:\s*\d+/, `nav: ${index + 25}`)
+          const updatedContent = content.replace(/nav:\s*\d+/, `nav: ${index + 26}`)
           fs.writeFileSync(targetFile, updatedContent)
         })
       }

--- a/packages/react/xr/src/default.tsx
+++ b/packages/react/xr/src/default.tsx
@@ -173,6 +173,7 @@ export function DefaultXRHandTouchPointer(props: DefaultXRHandTouchPointerOption
  * #### `model` - Options for configuring the controller apperance
  * #### `grabPointer` - Options for configuring the grab pointer
  * #### `rayPointer` - Options for configuring the ray pointer
+ * #### `teleportPointer` - Options for configuring the teleport pointer
  */
 export function DefaultXRController(props: DefaultXRControllerOptions) {
   const modelOptions = props.model

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -10,7 +10,8 @@ export { createXRHitTestSource, requestXRHitTest, type GetWorldMatrixFromXRHitTe
 /**
  * Hook for creating a hit test source originating from the provided object or XRSpace. The provided object must be statically positioned in the XRSpace.
  *
- * @param relativeTo - 
+ * @param relativeTo - The XRSpace, XRReferenceSpace, or Object3D to perform hit-tests from
+ * @param trackableType - The
  * 
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -11,11 +11,33 @@ export { createXRHitTestSource, requestXRHitTest, type GetWorldMatrixFromXRHitTe
  * Hook for creating a hit test source originating from the provided object or XRSpace. The provided object must be statically positioned in the XRSpace.
  *
  * @param relativeTo - The XRSpace, XRReferenceSpace, or Object3D to perform hit-tests from
- * @param trackableType - The
- * 
+ * @param trackableType - A string, or array of strings that specify the types of surfaces to hit test against ('point', 'plane', 'mesh')
+ *
+ * @example
+ * function ManualHitTest() {
+ *   const meshRef = useRef<Mesh>(null)
+ *   const hitTestSource = useXRHitTestSource('viewer')
+ *   const [someCondition, setSomeCondition] = useState(false)
+ *   const [hitResults, setHitResults] = useState<XRHitTestResult[]>([])
+ *
+ *   useFrame((_, __, frame: XRFrame | undefined) => {
+ *     // Only perform hit testing when certain conditions are met
+ *     if (frame && hitTestSource && someCondition) {
+ *       const results = frame.getHitTestResults(hitTestSource.source)
+ *       setHitResults(results)
+ *     }
+ *   })
+ *   return (
+ *     <IfInSessionMode allow={'immersive-ar'}>
+ *       <XRDomOverlay>
+ *         <button onClick={() => setSomeCondition(true)}>Turn on hit testing</button>
+ *       </XRDomOverlay>
+ *     </IfInSessionMode>
+ *   )
+ * }
+ *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
- */
  */
 export function useXRHitTestSource(
   relativeTo: RefObject<Object3D | null> | XRSpace | XRReferenceSpaceType,
@@ -28,6 +50,41 @@ export function useXRHitTestSource(
 
 /**
  * Hook for setting up a continous hit test originating from the provided object or XRSpace. The provided object must be statically positioned in the XRSpace.
+ *
+ * @param fn - Callback function that contains the results of the hit test, and a function to retrieve the world matrix
+ * @param relativeTo - The XRSpace, XRReferenceSpace, or Object3D to perform hit-tests from
+ * @param trackableType - A string, or array of strings that specify the types of surfaces to hit test against ('point', 'plane', 'mesh')
+ *
+ * @example
+ * const matrixHelper = new Matrix4()
+ * const hitTestPosition = new Vector3()
+ *
+ * function ContinuousHitTest() {
+ *   const previewRef = useRef<Mesh>(null)
+ *
+ *   useXRHitTest(
+ *     (results, getWorldMatrix) => {
+ *       if (results.length === 0) return
+ *
+ *       getWorldMatrix(matrixHelper, results[0])
+ *       hitTestPosition.setFromMatrixPosition(matrixHelper)
+ *     },
+ *     'viewer'
+ *   )
+ *
+ *   useFrame(() => {
+ *     if (hitTestPosition && previewRef.current) {
+ *       previewRef.current.position.copy(hitTestPosition)
+ *     }
+ *   })
+ *
+ *   return (
+ *       <mesh ref={previewRef} position={hitPosition}>
+ *         <sphereGeometry args={[0.05]} />
+ *         <meshBasicMaterial color="red" />
+ *       </mesh>
+ *   )
+ * }
  *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
@@ -87,6 +144,40 @@ function useCreateXRHitTestSource(
 /**
  * Hook that returns a function to request a single hit test. Cannot be called in the useFrame hook.
  *
+ * @example
+ * const matrixHelper = new Matrix4()
+ * function EventDrivenHitTest() {
+ *   const requestHitTest = useXRRequestHitTest()
+ *   const [placedObjects, setPlacedObjects] = useState<Vector3[]>([])
+ *
+ *   const handleTap = async () => {
+ *     const hitTestResult = await requestHitTest('viewer', ['plane', 'mesh'])
+ *     const { results, getWorldMatrix } = hitTestResult
+ *     if (results?.length > 0) {
+ *       getWorldMatrix(matrixHelper, results[0])
+ *       const position = new Vector3().setFromMatrixPosition(matrixHelper)
+ *       setPlacedObjects((prev) => [...prev, position])
+ *     }
+ *   }
+ *
+ *   return (
+ *     <>
+ *       <IfInSessionMode allow={'immersive-ar'}>
+ *         <XRDomOverlay>
+ *           <button onClick={handleTap}>Place Object</button>
+ *         </XRDomOverlay>
+ *       </IfInSessionMode>
+ *
+ *       {placedObjects.map((position, index) => (
+ *         <mesh key={index} position={position}>
+ *           <sphereGeometry args={[0.1]} />
+ *           <meshBasicMaterial color="blue" />
+ *         </mesh>
+ *       ))}
+ *     </>
+ *   )
+ * }
+ *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
  */
@@ -114,6 +205,30 @@ export function useXRRequestHitTest() {
  * @param props
  * #### `space` - [XRSpaceType](https://developer.mozilla.org/en-US/docs/Web/API/XRSpace) | [XRReferenceSpaceType](https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpace#reference_space_types)
  * #### `onResults` - Callback function that is called with the results of the hit test
+ *
+ * @example
+ * const matrixHelper = new Matrix4()
+ * const hitTestPosition = new Vector3()
+ *
+ * const store = createXRStore({
+ *   hand: () => {
+ *     const inputSourceState = useXRInputSourceStateContext()
+ *
+ *     return (
+ *       <>
+ *         <DefaultXRHand />
+ *         <XRHitTest
+ *           space={inputSourceState.inputSource.targetRaySpace}
+ *           onResults={(results, getWorldMatrix) => {
+ *             if (results.length === 0) return
+ *             getWorldMatrix(matrixHelper, results[0])
+ *             hitTestPosition.setFromMatrixPosition(matrixHelper)
+ *           }}
+ *         />
+ *       </>
+ *     )
+ *   },
+ * })
  *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -97,10 +97,13 @@ export function useXRRequestHitTest() {
 }
 
 /**
- * Component for getting hit tests originating based on its position in the scene graph
+ * A convenience wrapper component for the useXRHitTest hook. Used to setup hit testing in the scene.
  *
- * @param props ‎
+ * @param props
  * #### `space` - [XRSpaceType](https://developer.mozilla.org/en-US/docs/Web/API/XRSpace) | [XRReferenceSpaceType](https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpace#reference_space_types)
+ *
+ * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
+ * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
  * @function
  */
 export const XRHitTest = forwardRef<

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -8,7 +8,13 @@ import { useXRStore } from './xr.js'
 export { createXRHitTestSource, requestXRHitTest, type GetWorldMatrixFromXRHitTest } from '@pmndrs/xr'
 
 /**
- * Hook for creating a hit test source originating from the provided object or XRSpace. The provided object must be static
+ * Hook for creating a hit test source originating from the provided object or XRSpace. The provided object must be statically positioned in the XRSpace.
+ *
+ * @param relativeTo - 
+ * 
+ * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
+ * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
+ */
  */
 export function useXRHitTestSource(
   relativeTo: RefObject<Object3D | null> | XRSpace | XRReferenceSpaceType,
@@ -20,7 +26,7 @@ export function useXRHitTestSource(
 }
 
 /**
- * Hook for setting up a continous hit test originating from the provided object or XRSpace. The provided object must be static
+ * Hook for setting up a continous hit test originating from the provided object or XRSpace. The provided object must be statically positioned in the XRSpace.
  *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -15,7 +15,6 @@ export function useXRHitTestSource(
   trackableType?: XRHitTestTrackableType | Array<XRHitTestTrackableType>,
 ) {
   const [source, setState] = useState<Awaited<ReturnType<typeof createXRHitTestSource>> | undefined>()
-  // eslint-disable-next-line react-hooks/rules-of-hooks
   useCreateXRHitTestSource(relativeTo, trackableType, setState)
   return source
 }

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -8,7 +8,7 @@ import { useXRStore } from './xr.js'
 export { createXRHitTestSource, requestXRHitTest, type GetWorldMatrixFromXRHitTest } from '@pmndrs/xr'
 
 /**
- * Hook for creating a hit test source originating from the provided object or xrspace
+ * Hook for creating a hit test source originating from the provided object or XRSpace. The provided object must be static
  */
 export function useXRHitTestSource(
   relativeTo: RefObject<Object3D | null> | XRSpace | XRReferenceSpaceType,
@@ -20,7 +20,7 @@ export function useXRHitTestSource(
 }
 
 /**
- * Hook for setting up a continous hit test originating from the provided object or xrspace
+ * Hook for setting up a continous hit test originating from the provided object or XRSpace. The provided object must be static
  *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
@@ -78,7 +78,7 @@ function useCreateXRHitTestSource(
 }
 
 /**
- * Hook that returns a function to request a single hit test
+ * Hook that returns a function to request a single hit test. Cannot be called in the useFrame hook.
  *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
@@ -106,6 +106,7 @@ export function useXRRequestHitTest() {
  *
  * @param props
  * #### `space` - [XRSpaceType](https://developer.mozilla.org/en-US/docs/Web/API/XRSpace) | [XRReferenceSpaceType](https://developer.mozilla.org/en-US/docs/Web/API/XRReferenceSpace#reference_space_types)
+ * #### `onResults` - Callback function that is called with the results of the hit test
  *
  * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
  * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)

--- a/packages/react/xr/src/hit-test.tsx
+++ b/packages/react/xr/src/hit-test.tsx
@@ -22,6 +22,9 @@ export function useXRHitTestSource(
 
 /**
  * Hook for setting up a continous hit test originating from the provided object or xrspace
+ *
+ * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
+ * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
  */
 export function useXRHitTest(
   fn: ((results: Array<XRHitTestResult>, getWorldMatrix: GetWorldMatrixFromXRHitTest) => void) | undefined,
@@ -77,6 +80,9 @@ function useCreateXRHitTestSource(
 
 /**
  * Hook that returns a function to request a single hit test
+ *
+ * @see [Hit Test Tutorial](https://pmndrs.github.io/xr/docs/tutorials/hit-test)
+ * @see [Hit Test Example](https://pmndrs.github.io/xr/examples/hit-testing/)
  */
 export function useXRRequestHitTest() {
   const store = useXRStore()

--- a/packages/react/xr/src/input.tsx
+++ b/packages/react/xr/src/input.tsx
@@ -10,7 +10,7 @@ import { useContext, useEffect } from 'react'
 import { xrInputSourceStateContext } from './contexts.js'
 import { useXR } from './xr.js'
 
-export type { XRTransientPointerState, XRScreenInputState, XRGazeState }
+export type { XRGazeState, XRScreenInputState, XRTransientPointerState }
 
 export function useXRInputSourceStates() {
   return useXR((xr) => xr.inputSourceStates)
@@ -31,7 +31,9 @@ export function useXRInputSourceState<T extends keyof XRInputSourceStateMap>(
 export function useXRInputSourceStateContext<T extends keyof XRInputSourceStateMap>(type: T): XRInputSourceStateMap[T]
 
 export function useXRInputSourceStateContext(): XRInputSourceState
-
+/**
+ * Retrieves the current state for input sources. Useful for accessing input source ray spaces
+ * */
 export function useXRInputSourceStateContext<T extends keyof XRInputSourceStateMap>(
   type?: T,
 ): XRInputSourceStateMap[T] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -180,6 +180,12 @@ importers:
 
   examples/hit-testing:
     dependencies:
+      '@react-three/handle':
+        specifier: workspace:~
+        version: link:../../packages/react/handle
+      '@react-three/uikit':
+        specifier: ^0.8.21
+        version: 0.8.21(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
       '@react-three/xr':
         specifier: workspace:~
         version: link:../../packages/react/xr
@@ -838,6 +844,9 @@ packages:
   '@pmndrs/handle@6.6.1':
     resolution: {integrity: sha512-gMYeKxrYPkZV6qocLO/N3yxfAio2i7VzvtRrA4rUGivNHZhImXWWikJZa8hzyQp/bNG4tbRo6KE3T4CGmrmTvg==}
 
+  '@pmndrs/msdfonts@0.8.21':
+    resolution: {integrity: sha512-6SY68a5JnjTENJ0RnYuylJJPN2XTTnnhVTf7fngYr1dp4k+FOO5WHhrEWK0E44sU2KpR46GPAv6lt9U5qebhpQ==}
+
   '@pmndrs/msdfonts@0.8.7':
     resolution: {integrity: sha512-O+2xzQQeIV249SfuSJVsAIun2/9SnA9V2P90NRDxzRYVzI8smXk6na1iA7E/RsCvfpWFhyX3g9zaKdiTotavoA==}
 
@@ -854,6 +863,11 @@ packages:
 
   '@pmndrs/uikit@0.5.4':
     resolution: {integrity: sha512-kTjMxCbLMuKFRlT2LRND5elcXaXtghwiy41D79Gy9rt7q2uWUjdWSvE3u/8hzHK2B/zEnkoLda61B5S1/hojRg==}
+    peerDependencies:
+      three: '>=0.160'
+
+  '@pmndrs/uikit@0.8.21':
+    resolution: {integrity: sha512-C61c2OmCKHwLNkun/ZJYadFQBswBPN19dAwyuawV02xkbHJZ9iZZlx0ywRRXrYWNYiM4Ut5TiPKJPVXIg0Z9+w==}
     peerDependencies:
       three: '>=0.160'
 
@@ -941,6 +955,13 @@ packages:
 
   '@react-three/uikit@0.5.4':
     resolution: {integrity: sha512-SilREiJdUzfXTvV7DWSZTpbSXb43jGP/Bb89gd+ta1PL+0UB47L9lAQkM7sQM9N5MweP28rlZkAQ6SYIwAAXtA==}
+    hasBin: true
+    peerDependencies:
+      '@react-three/fiber': '>=8'
+      react: '>=18'
+
+  '@react-three/uikit@0.8.21':
+    resolution: {integrity: sha512-auV2MVY/NiseQ3dAa5VcsE4KbLfzARnlfEZGDw668r8SO7rgvVDfANmEyVvr0NyVT8rxK+KnNujF5xhxQCQaXQ==}
     hasBin: true
     peerDependencies:
       '@react-three/fiber': '>=8'
@@ -3698,6 +3719,8 @@ snapshots:
       - immer
       - react
 
+  '@pmndrs/msdfonts@0.8.21': {}
+
   '@pmndrs/msdfonts@0.8.7': {}
 
   '@pmndrs/pointer-events@6.6.1': {}
@@ -3722,6 +3745,18 @@ snapshots:
 
   '@pmndrs/uikit@0.5.4(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
     dependencies:
+      '@preact/signals-core': 1.8.0
+      inline-style-parser: 0.2.4
+      node-html-parser: 6.1.13
+      three: 0.173.0
+      tw-to-css: 0.0.12(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      yoga-layout: 3.2.1
+    transitivePeerDependencies:
+      - ts-node
+
+  '@pmndrs/uikit@0.8.21(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+    dependencies:
+      '@pmndrs/msdfonts': 0.8.21
       '@preact/signals-core': 1.8.0
       inline-style-parser: 0.2.4
       node-html-parser: 6.1.13
@@ -3897,6 +3932,26 @@ snapshots:
       prettier: 3.4.2
       prompts: 2.4.2
       react: 19.0.0
+      zod: 3.24.1
+      zustand: 4.5.6(@types/react@19.0.8)(react@19.0.0)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+      - three
+      - ts-node
+
+  '@react-three/uikit@0.8.21(@react-three/fiber@9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0))(@types/react@19.0.8)(react@19.0.0)(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))':
+    dependencies:
+      '@pmndrs/uikit': 0.8.21(three@0.173.0)(ts-node@10.9.2(@types/node@22.13.0)(typescript@5.7.3))
+      '@preact/signals-core': 1.8.0
+      '@react-three/fiber': 9.0.0-rc.5(@types/react@19.0.8)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)(three@0.173.0)
+      chalk: 5.4.1
+      commander: 12.1.0
+      ora: 8.1.1
+      prettier: 3.4.2
+      prompts: 2.4.2
+      react: 19.0.0
+      suspend-react: 0.1.3(react@19.0.0)
       zod: 3.24.1
       zustand: 4.5.6(@types/react@19.0.8)(react@19.0.0)
     transitivePeerDependencies:


### PR DESCRIPTION
# Changes 
- Updated the hit testing tutorial to touch on each hit-testing hook in depth
- Updated the hit testing example to use every hook that the library offers
- Updated the jsdoc in the hooks to include descriptions of each parameter and examples of how to use the hooks. 
- Added the teleportPointer to the parameters of the DefaultXRController in the JSDoc

# Screenshots
<img width="3406" height="1301" alt="image" src="https://github.com/user-attachments/assets/880679f2-7760-4e51-9c9d-9ffff247c590" />
<img width="1914" height="1096" alt="image" src="https://github.com/user-attachments/assets/ef3d82ca-8ca1-49ff-9df7-4446d3ed523c" />
<img width="1918" height="1039" alt="image" src="https://github.com/user-attachments/assets/6ba5a115-2afb-44b1-af95-f8466939cf57" />
![Screenshot_20250827_215341_Chrome](https://github.com/user-attachments/assets/3ee50489-c058-41e8-9b37-2bde619a9233)
