### PR TITLE
fix: Fixing the minecraft example movement

### DIFF
--- a/examples/minecraft/src/App.tsx
+++ b/examples/minecraft/src/App.tsx
@@ -1,4 +1,4 @@
-import { Sky, PointerLockControls, KeyboardControls } from '@react-three/drei'
+import { KeyboardControls, Sky } from '@react-three/drei'
 import { Canvas } from '@react-three/fiber'
 import { interactionGroups, Physics } from '@react-three/rapier'
 import { createXRStore, XR } from '@react-three/xr'
@@ -56,7 +56,6 @@ export function App() {
               <Cube collisionGroups={interactionGroups([0, 1], [0])} position={[0, 0.5, -10]} />
               <Cubes />
             </Physics>
-            <PointerLockControls />
           </XR>
         </Canvas>
       </KeyboardControls>

--- a/examples/minecraft/src/Player.tsx
+++ b/examples/minecraft/src/Player.tsx
@@ -8,7 +8,7 @@ import {
   useRapier,
   Vector3Object,
 } from '@react-three/rapier'
-import { IfInSessionMode } from '@react-three/xr'
+import { IfInSessionMode, useXR } from '@react-three/xr'
 import { useRef } from 'react'
 import * as THREE from 'three'
 import { Axe } from './Axe.jsx'
@@ -31,6 +31,7 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
   const { rapier, world } = useRapier()
   const [, getKeys] = useKeyboardControls()
   const { camera } = useThree()
+  const { mode } = useXR()
 
   const playerMove = ({
     forward,
@@ -137,7 +138,8 @@ export function Player({ lerp = THREE.MathUtils.lerp }) {
         right,
         rotationYVelocity: 0,
         velocity,
-        camera: state.camera,
+        // Don't pass the camera in AR/VR mode, as we want the player to control rotation
+        camera: mode?.includes('immersive-ar') || mode?.includes('immersive-vr') ? undefined : state.camera,
       })
 
       if (jump) {


### PR DESCRIPTION
Currently the Minecraft example is broken in the desktop version. The movement does not line up with the direction that the camera is facing. 

# Changes
- Updated the example to properly base the movement on camera rotation when not in VR or AR.  
- Properly linked the `PointerLockControls` to the camera